### PR TITLE
remove "Next steps" sections from all pages

### DIFF
--- a/add-lxd-nodes.md
+++ b/add-lxd-nodes.md
@@ -26,13 +26,13 @@ List the available machines to confirm it has been added:
 ```bash
 $ juju list-machines
 Machine  State    DNS           Inst id              Series AZ Message
-0    	  started  192.168.1.9   manual:192.168.1.9   bionic  Manually provisioned machine 
+0    	  started  192.168.1.9   manual:192.168.1.9   bionic  Manually provisioned machine
 1    	  started  192.168.1.10  manual:192.168.1.10  bionic  Manually provisioned machine
 2    	  started  192.168.1.11  manual:192.168.1.11  bionic  Manually provisioned machine
 ```
 
 As before, take care that a new machine is in the `started` state before you proceed. If
-still in `down` state, please wait until it switches to `started`. 
+still in `down` state, please wait until it switches to `started`.
 
 When the environment is ready, you can add the additional LXD node by requesting Juju to add a new unit of the LXD charm onto machine 2:
 
@@ -41,7 +41,3 @@ $ juju add-unit lxd --to 2
 ```
 
 Once the unit is deployed it is added automatically added to AMS as a new LXD node.
-
-## Next Steps
- * [Node Management](https://discourse.ubuntu.com/t/managing-lxd-nodes/17757)
- 

--- a/application-testing.md
+++ b/application-testing.md
@@ -117,8 +117,3 @@ After the container is up and running, you need to specify the proper `appPackag
   "appActivity": ".MainActivity"
 }
 ```
-
-## Next Steps
-
-* [Application Management](https://discourse.ubuntu.com/t/managing-applications/17760)
-* [Container Management](https://discourse.ubuntu.com/t/managing-containers/17763)

--- a/container-access.md
+++ b/container-access.md
@@ -106,8 +106,3 @@ And run the scrcpy to display and control the Android container.
 ```bash
 $ scrcpy
 ```
-
-## Next Steps
-
- * [Application Management](https://discourse.ubuntu.com/t/managing-applications/17760)
- 

--- a/customizing.md
+++ b/customizing.md
@@ -230,15 +230,6 @@ $ juju gui
 
 Running this command will output some login information and a URL for the GUI interface (the GUI actually runs on the Juju controller instance). On visiting the URL given and logging in, a graphical representation of the current model will be shown. To export the model as a YAML bundle, click on the **Export** button near the top left of the screen.
 
-![Anbox Cloud - Juju GUI|690x444](upload://bXqb0LwD7EBZDwL18CsZSBZqL5r.png) 
+![Anbox Cloud - Juju GUI|690x444](upload://bXqb0LwD7EBZDwL18CsZSBZqL5r.png)
 
 For more information on the Juju GUI, see the [Juju documentation](https://docs.jujucharms.com/stable/en/controllers-gui).
-
-
-## Next Steps
-
-* [High Availability](https://discourse.ubuntu.com/t/high-availability/17754)
-* [Metrics](https://discourse.ubuntu.com/t/metrics-collection/17753)
-* [Adding additional LXD node](https://discourse.ubuntu.com/t/adding-additional-lxd-nodes/17752)
-* [Image management](https://discourse.ubuntu.com/t/managing-images/17758)
-* [Application management](https://discourse.ubuntu.com/t/managing-applications/17760/2)

--- a/getting-started.md
+++ b/getting-started.md
@@ -61,7 +61,7 @@ To create an application through the web dashboard, open `https://<your-machine-
 
 ### Create an application on the command line
 
-To create and manage an application from the command line, use `amc`. 
+To create and manage an application from the command line, use `amc`.
 
 You must provide a `manifest.yaml` file for your application. In its simplest form, the manifest looks like this:
 
@@ -85,8 +85,3 @@ You can use the `amc application show <app name>` command to display the status 
 When processing is done, you can start a container for your new application by launching the application:
 
     amc launch <app name>
-
-## Next steps
-* [Image Management](https://discourse.ubuntu.com/t/managing-images/17758)
-* [Container Management](https://discourse.ubuntu.com/t/managing-containers/17763)
-* [Application Management](https://discourse.ubuntu.com/t/managing-applications/17760)

--- a/manage-containers.md
+++ b/manage-containers.md
@@ -49,7 +49,7 @@ When launching a container from an application or an image directly, a regular c
   * Execute the `prepare` hook provided by the installed addons if [lauching a raw container](#heading--raw-containers)
   * Execute the `backup` hook provided by the installed addons after the container is terminated
 
-![container-launch|690x401](upload://exw6GWcRvMzkIztcUIrizFg0oJz.png) 
+![container-launch|690x401](upload://exw6GWcRvMzkIztcUIrizFg0oJz.png)
 
 The whole launch process will be successful only if all of the above steps succeed.
 
@@ -319,8 +319,3 @@ $ amc ls --filter type=regular --filter node=lxd0
 ```
 
 This will query all regular containers that are placed on the node with the name `lxd0`.
-
-## Next Steps
-
- * [Application Management](https://discourse.ubuntu.com/t/managing-applications/17760)
- 

--- a/manage-images.md
+++ b/manage-images.md
@@ -100,7 +100,3 @@ Now that a new image version is available to AMS, it will start to create new ve
     amc application show <id>
 
 Each version will give information about which version of an image it is based on.
-
-## Next steps
-
- * [Application Management](https://discourse.ubuntu.com/t/managing-applications/17760)

--- a/virtual-devices.md
+++ b/virtual-devices.md
@@ -2,7 +2,7 @@ Anbox Cloud allows you to stream the whole Android experience next to just indiv
 
 ## Create an Application for the Virtual Device
 
-In order to create a virtual device experience we first have to create an application with AMS. This application will not contain any APK and with that will start directly into the Android system launcher and provide the full Android experience. 
+In order to create a virtual device experience we first have to create an application with AMS. This application will not contain any APK and with that will start directly into the Android system launcher and provide the full Android experience.
 
 A very simple application manifest for such an application looks like this:
 
@@ -16,7 +16,7 @@ instance-type: a4.3
 
 ## Extend the Application with Addons
 
-You can also extend the application with [addons](https://discourse.ubuntu.com/t/managing-addons/17759/2) which install additional applications you want to offer as part of your default experience. You can for example replace the standard Android launcher with a custom one like [Lawnchair](https://lawnchair.app/). 
+You can also extend the application with [addons](https://discourse.ubuntu.com/t/managing-addons/17759/2) which install additional applications you want to offer as part of your default experience. You can for example replace the standard Android launcher with a custom one like [Lawnchair](https://lawnchair.app/).
 
 ```bash
 $ mkdir -p vdev-support/hooks
@@ -50,7 +50,7 @@ EOF
 
 $ chmod +x hooks/*
 $ amc addon add vdev-support .
-``` 
+```
 
 Once the addon is uploaded to AMS, you can reference it from your application manifest:
 
@@ -67,9 +67,4 @@ The application will now include the [Lawnchair](https://lawnchair.app/) and has
 
 Now that we have the application created in AMS we can go ahead and stream it through the UI of the Anbox Stream Gateway (see [Getting started with Anbox Cloud](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud/17756) for more details) or your own custom client application build with the [Anbox Stream SDK](https://discourse.ubuntu.com/t/anbox-streaming-sdk/17783).
 
-![anbox-vdev|690x662,100%](upload://aX9HNy8aMxJxSdZHJvtf4PHa3hH.png) 
-
-## Next Steps
-
-* [Application Management](https://discourse.ubuntu.com/t/managing-applications/17760)
-* [Container Management](https://discourse.ubuntu.com/t/managing-containers/17763)
+![anbox-vdev|690x662,100%](upload://aX9HNy8aMxJxSdZHJvtf4PHa3hH.png)


### PR DESCRIPTION
Most of these sections are outdated anyway, and they won't
really make sense once we move the pages around.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>