### PR TITLE
add grouping pages

### DIFF
--- a/howto-applications.md
+++ b/howto-applications.md
@@ -1,0 +1,5 @@
+The guides in this section describe how to manage your applications.
+
+See [About applications](https://discourse.ubuntu.com/t/managing-applications/17760) for an introduction to how applications are used in Anbox Cloud.
+
+To check which configuration options are available for applications, see [Application manifest](https://discourse.ubuntu.com/t/application-manifest/24197).

--- a/howto-clustering.md
+++ b/howto-clustering.md
@@ -1,0 +1,3 @@
+The guides in this section describe how to distribute the load of your Anbox Cloud installation over several machines in a cluster.
+
+See [About clustering](https://discourse.ubuntu.com/t/capacity-planning/17765) for an introduction to how clustering works in Anbox Cloud.

--- a/howto-containers.md
+++ b/howto-containers.md
@@ -1,0 +1,3 @@
+The guides in this section describe how to work with containers.
+
+See [About containers](https://discourse.ubuntu.com/t/managing-containers/17763) for an introduction to how containers are used in Anbox Cloud.

--- a/howto-install.md
+++ b/howto-install.md
@@ -1,0 +1,5 @@
+The guides in this section describe how to install Anbox Cloud.
+
+> **NOTE:** There is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [Installing the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).
+
+Make sure to check the [Requirements](https://discourse.ubuntu.com/t/installation-requirements/17734) before you start your installation.

--- a/howto-manage.md
+++ b/howto-manage.md
@@ -1,0 +1,1 @@
+The guides in this section describe how to manage and work with your Anbox Cloud or Anbox Cloud Appliance installation.

--- a/howto-monitor.md
+++ b/howto-monitor.md
@@ -1,0 +1,3 @@
+The guides in this section describe how to monitor your Anbox Cloud or Anbox Cloud Appliance installation.
+
+To check which metrics are available for monitoring, see [Prometheus metrics](https://discourse.ubuntu.com/t/prometheus-metrics/19521).

--- a/howto-streaming.md
+++ b/howto-streaming.md
@@ -1,0 +1,5 @@
+The guides in this section describe how to use the Streaming Stack to implement specific streaming features in your application.
+
+See [Streaming Android Applications](https://discourse.ubuntu.com/t/streaming-android-applications/17769) for an introduction to the Streaming Stack.
+
+For an introduction to the Streaming SDK, see [Anbox Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk).

--- a/howto-update.md
+++ b/howto-update.md
@@ -1,0 +1,1 @@
+The guides in this section describe how to update your Anbox Cloud or Anbox Cloud Appliance installation.

--- a/overview.md
+++ b/overview.md
@@ -1,5 +1,6 @@
 Anbox Cloud provides a rich software stack to enable you to run Android in the cloud for all kinds of different uses cases. This page intends to give you an overview over the available variants and internal components which make Anbox Cloud.
 
+<a name="variants"></a>
 ## Variants
 
 Anbox Cloud exists in two different variants which serve different purposes:
@@ -40,7 +41,7 @@ Starting from 1.4, Anbox Cloud comes with an easy to use streaming solution. The
 
 The following picture shows an overview of how the different components work together to enable this.
 
-![streaming-stack-overview|690x440](upload://qXJleBmvwQFi2cc1HuPF7P5S15b.png) 
+![streaming-stack-overview|690x440](upload://qXJleBmvwQFi2cc1HuPF7P5S15b.png)
 
 Main components powering the streaming stack in Anbox Cloud:
 

--- a/reference-api.md
+++ b/reference-api.md
@@ -1,0 +1,3 @@
+The documentation in this section provides a reference for the APIs that are used or provided by Anbox Cloud.
+
+Also see [SDKs](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844) for a more detailed description of the SDKs that Anbox Cloud provides.


### PR DESCRIPTION
These pages will be needed to group some of the existing pages
(mainly the howto pages) together in the navigation.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>