### PR TITLE
Drop all references to oem-share

### DIFF
--- a/explanation/anbox-cloud.md
+++ b/explanation/anbox-cloud.md
@@ -32,7 +32,7 @@ A developer or system administrator will manage **AMS** through the **command li
 
 For example, a simple Android application testing service would provide a user-facing interface dealing with things like authentication and user management, and would communicate with the REST API to add applications or start and stop containers when a user asks to.
 
-Anbox Cloud can be heavily customized and extended via [**Platform Plugins**](https://oem-share.canonical.com/partners/indore/share/docs/1.7/en/sdk/anbox/) and [**addons**](https://discourse.ubuntu.com/t/managing-addons/17759). Platform plugins and addons can be built to add specific streaming capabilities, perform operations within Android containers and much more. One example of a platform plugin is the **Anbox WebRTC Platform** used in the Anbox Streaming Stack. Addons are ways to customize the base image by installing additional software and running scripts on different lifecycle hooks.
+Anbox Cloud can be heavily customized and extended via [**Platform Plugins**](https://anbox-cloud.github.io/1.10/anbox-platform-sdk/index.html) and [**addons**](https://discourse.ubuntu.com/t/managing-addons/17759). Platform plugins and addons can be built to add specific streaming capabilities, perform operations within Android containers and much more. One example of a platform plugin is the **Anbox WebRTC Platform** used in the Anbox Streaming Stack. Addons are ways to customize the base image by installing additional software and running scripts on different lifecycle hooks.
 
 
 ### Streaming Stack

--- a/explanation/benchmarking.md
+++ b/explanation/benchmarking.md
@@ -110,25 +110,6 @@ You can configure a different display specification through the `--user-data` pa
 
 > **Note:** If you're running a benchmark against the `webrtc` platform, make sure to specify `"render_only": true` to launch the containers in render-only mode. Otherwise, the container creation will fail, because the `amc benchmark` command doesn't interact with the stream gateway for the benchmark execution.
 
-### Example Stress Test Application
-
-In order to make evaluation and testing easier we provide a GPU stress test application based on an [example application](https://github.com/google/gpu-emulation-stress-test) from Google.
-The application is a stress test which is primarily being used to verify the OpenGL emulation of the Android emulator but serves general stress test purposes as well.
-
-The application was modified to constantly run the benchmark scene with `~1000` objects to drive CPU and GPU utilization of a container. You can find the application APK package here:
-
-* [Stress Test Application (amd64 + arm64, sha256: dfb67bb97ceb5e3c64398210e2ecd65286f14b0c67856abde2ac0bead07bd223)](https://oem-share.canonical.com/partners/indore/share/releases/1.8/other/com.android.gpu_emulation_stress_test_1.8.apk)
-
-Once downloaded you can add the application as regular application (see [Create an application](https://discourse.ubuntu.com/t/create-an-application/24198)) to your Anbox Cloud installation. The manifest may look like:
-
-```yaml
-name: gpu-stress-test
-instance: a2.3
-image: default
-```
-
-> **Hint:** Depending on the selected instance type and how powerful a single core of your machines is you may get better results with a larger instance type.
-
 ## Stream Benchmarking
 
 As streaming involves more things to automate for a proper benchmark Anbox Cloud provides a dedicated benchmark tool which allows creating a streaming session, receiving the video/audio stream and collecting various statistics and optional also dumping the received stream to a local file.

--- a/reference/anbox-http-api.md
+++ b/reference/anbox-http-api.md
@@ -99,7 +99,7 @@ $ curl -s -X GET --unix-socket /run/user/1000/anbox/sockets/api.unix s/1.0 | jq 
  * Operation: sync
  * Return: Current location status
 
-> **NOTE:**  After enabling the location endpoint, any location updates provided via the [Anbox Platform API](https://oem-share.canonical.com/partners/indore/share/docs/1.7/en/sdk/anbox/) won't be processed by Anbox until the location endpoint is disabled again.
+> **NOTE:**  After enabling the location endpoint, any location updates provided via the [Anbox Platform API](https://anbox-cloud.github.io/1.10/anbox-platform-sdk/index.html) won't be processed by Anbox until the location endpoint is disabled again.
 
  Return value:
 

--- a/reference/platforms.md
+++ b/reference/platforms.md
@@ -1,4 +1,4 @@
-Anbox can make use of different [platforms](https://oem-share.canonical.com/partners/indore/share/docs/1.7/en/sdk/anbox/) to customize its behavior. Anbox Cloud currently supports 3 platforms. Which one to use depends on your needs.
+Anbox can make use of different [platforms](https://anbox-cloud.github.io/1.10/anbox-platform-sdk/index.html) to customize its behavior. Anbox Cloud currently supports 3 platforms. Which one to use depends on your needs.
 
 ## Supported platforms
 

--- a/reference/provided-images.md
+++ b/reference/provided-images.md
@@ -1,6 +1,6 @@
 Anbox Cloud provides images based on different Android versions and different architectures (amd64, arm64). AMS manages these images, which can be individually selected by applications. When an image is updated, all applications using the image are automatically updated and rebased on the new image version.
 
-Officially released images are available for each version of Anbox Cloud, either on the [Downloads](https://oem-share.canonical.com/partners/indore/share/docs/1.7/en/installation-downloads.html) page (for versions <= 1.7) or on an image server hosted by Canonical.
+Officially released images are available from the [official image server](https://images.anbox-cloud.io) hosted by Canonical.
 
 > **Note**: Anbox images are regular [Ubuntu cloud images](https://cloud-images.ubuntu.com/) where Anbox and its dependencies are installed. Unnecessary packages are removed to improve images size, boot time and security.
 


### PR DESCRIPTION
Nobody has access to oem-share outside of Canonical at this point so
linking to it doesn't make sense. This uses a static link to the 1.10
platform SDK API but we should look for a better way to manage the
different references we have to it.