### PR TITLE
fix docs for updating applications

### DIFF
--- a/howto/application/update.md
+++ b/howto/application/update.md
@@ -81,7 +81,11 @@ resources:
 Each version gets a monotonically increasing number assigned (here we have version `0` and version `1`).
 In addition, each version has a status which indicates the status of the bootstrap process AMS is performing for it. Once an application version is marked as `active`, it is ready to be used.
 
+## Publish application versions
+
 The most important part of an application version is the `published` field. If a version is marked as published, it is accessible to users of Anbox Cloud. Generally when launching containers by using the AMS REST API, if no specific application version is given, the last published version of an application is used to create the container.
+
+If [`application.auto_publish`](https://discourse.ubuntu.com/t/ams-configuration/20872) is set to `true` (the default), new versions are automatically published. Otherwise, you need to publish them manually.
 
 You can mark an application version as published with the following command:
 
@@ -92,6 +96,8 @@ To revoke an application version, use the following command:
     amc application revoke bcmap7u5nof07arqa2ag 1
 
 If an application has only a single published version and that version is revoked, the application can't be used by any users anymore. AMS will still list the application but will mark it as not published as it has no published versions.
+
+## Delete application versions
 
 Each version takes up space on the LXD nodes. To free up space and remove old and unneeded versions, you can individually remove them, with the only requirement that an application must have at least a single version at all times. Removing a specific application version is possible with the following command:
 

--- a/reference/ams-configuration.md
+++ b/reference/ams-configuration.md
@@ -5,6 +5,7 @@ AMS provides various configuration items to customize its behavior. The followin
 |-----------|------------|----|-------------------------|--------------------|
 | `application.addons` | string| -  |Comma separate listed of addons every application managed by AMS should use. |
 | `application.auto_publish` | boolean | true | If set to `true` AMS will automatically publish new applications versions when they finished the bootstrap process. `false` disables this. |
+| `application.auto_update` | boolean | true | If set to `true` AMS will automatically update applications whenever any dependencies (parent image, addons, global configuration) change. `false` disables this. |
 | `application.default_abi` | string | - | Default Android ABI applications should use. See https://developer.android.com/ndk/guides/abis for a list of available ABIs|
 |`application.max_published_versions` | integer | 3 | Maximum number of published versions per application. If the number of versions of an application is higher, AMS will automatically clean up older versions. |
 |`container.default_platform` | string | -  | Set to the platform name Anbox should use by default |


### PR DESCRIPTION
Adding information about auto_publish to the howto, and
auto_update to the list of AMS configuration options.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>