### PR TITLE
Correct release notes for 1.12.1

### DIFF
--- a/announcements/1.12.1.md
+++ b/announcements/1.12.1.md
@@ -6,7 +6,6 @@ Please see [component versions](https://anbox-cloud.io/docs/component-versions) 
 
 #### New features & improvements
 
- * Android WebView has been updated to [96.0.4664.45](https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html)
  * Improved graphics stability on Arm64 machines with NVIDIA GPUs
 
 #### Bugs

--- a/release-notes.md
+++ b/release-notes.md
@@ -8,7 +8,6 @@ See [Upgrade Anbox Cloud](https://discourse.ubuntu.com/t/upgrading-from-previous
 
 ### New features & improvements
 
- * Android WebView has been updated to [96.0.4664.45](https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html)
  * Improved graphics stability on Arm64 machines with NVIDIA GPUs
 
 ### Known issues


### PR DESCRIPTION
We didn't release webview 96 as written here. It will come with 1.12.2