### PR TITLE
feat(many): mark swrast as deprecated and replace everywhere

### DIFF
--- a/explanation/gpu-support.md
+++ b/explanation/gpu-support.md
@@ -29,26 +29,14 @@ AMS configures a LXD container to passthrough a GPU device from the host. As of 
 
 If a GPU driver is available inside the container there are no further differences of how to use it in comparison to a regular environment.
 
-If you want to let an application use the GPU but are not interested in streaming its visual output, you can simply launch a container with the `webrtc` platform. The platform will automatically detect the underlying GPU and make use of it.
+If you want to let an application use the GPU (even if you are not interested in streaming the visual output), launch it with the `--enable-graphics` flag. With this flag, the command will launch the container using the `webrtc` platform, which will automatically detect the underlying GPU and make use of it.
 
 ```bash
-$ amc launch -p webrtc my-application
+$ amc launch --enable-graphics my-application
 ```
 
 ## Force Software Rendering and Video Encoding
 
 [note type="information" status="Note"]Software rendering and video encoding will utilize the CPU. This will mean you can run less containers on a system than you can, when you have a GPU.[/note]
 
-It is possible to force a container to run with software rendering. For that simply launch a container with
-
-```bash
-$ amc launch -p swrast my-application
-```
-
-This will start the container with the `swrast` platform which forces software based rendering.
-
-If you want to force an application to use software rendering and video encoding when streaming via the Anbox Stream Gateway you can simply set a an [instance type](https://discourse.ubuntu.com/t/instance-types/17764) which doesn't require a GPU slot. For example
-
-```bash
-$ amc application set my-app instance-type a4.3
-```
+It is possible to tell a container to run with software rendering. For that, simply change the [instance type](https://discourse.ubuntu.com/t/instance-types/17764) or [resources](https://discourse.ubuntu.com/t/configure-available-resources/24960) of the application to not require a GPU. Anbox will then automatically determine that no GPU is available and use software rendering instead if a container is launched with graphics enabled.

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -7,13 +7,13 @@ As most deployments don't include GPUs we're going to use the `swrast` software 
 If you want to automate the UI tests against an APK which is externally provided, you can launch a raw container:
 
 ```bash
-$ amc launch -s adb -p swrast -r default
+$ amc launch -s adb --enable-graphics -r default
 ```
 
 This will create a container which exposes the TCP port `5559` on its private address from the default image `default`. If you want to expose ADB on the public address of a node, you can add the `+` from the service endpoint specification. With that the command looks as follows:
 
 ```bash
-$ amc launch -s +adb -p swrast -r
+$ amc launch -s +adb --enable-graphics -r
 ```
 
 [note type="information" status="Hint"]If you're wondering about the syntax of the command used to launch a container, see [Launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327).[/note]
@@ -21,7 +21,7 @@ $ amc launch -s +adb -p swrast -r
 If you want to run the Appium tests against an Android application managed by AMS (see [Create an application](https://discourse.ubuntu.com/t/create-an-application/24198)) you can start a regular container instead:
 
 ```bash
-$ amc launch -s adb -p swrast --disable-watchdog app
+$ amc launch -s adb --enable-graphics --disable-watchdog app
 ```
 
 [note type="information" status="Hint"]The `--disable-watchdog` argument is important as by default Anbox prevents Android from switching its foreground application and terminates when the application is stopped. To prevent this we need to disable the watchdog which is responsible for this.[/note]
@@ -102,7 +102,7 @@ EOF
 Once the application is fully bootstrapped by AMS, you can launch a container for it with the following command:
 
 ```bash
-$ amc launch -s +adb -p swrast --disable-watchdog app
+$ amc launch -s +adb --enable-graphics --disable-watchdog app
 ```
 
 After the container is up and running, you need to specify the proper `appPackage` and `appActivity` in the Appium preset, the installed Android application will be launched automatically in the container when a new session is created by Appium.

--- a/howto/container/access.md
+++ b/howto/container/access.md
@@ -41,11 +41,9 @@ Scrcpy is not available from the official Ubuntu repositories. Therefore, you mu
 
 ### Launch container
 
-To interact with scrcpy, each container must be leveraging proper graphics drivers to work. At best the container is launched with a platform that has a proper GPU supported if the deployment includes the [GPU support](https://discourse.ubuntu.com/t/gpu-support/17768). Otherwise, you can use the `swrast` platform instead, which provides a software rendering graphics driver based on [swiftshader](https://swiftshader.googlesource.com/SwiftShader). The `swrast` platform has been included in the official released images that can be downloaded from an image server hosted by Canonical. We will use the `swrast` platform in the following example.
+First, launch a container with graphics enabled:
 
-First, launch a container with the `swrast` platform:
-
-    amc launch -s +adb -p swrast -r default
+    amc launch -s +adb --enable-graphics -r default
 
 The above command will launch a container from the default image. Since scrcpy requires ADB to establish the connection between your host and the container, the ADB service must be enabled by default. With the leading `+` symbol to the `adb` service, it exposes TCP port 5559 on the public address of the node.
 
@@ -86,7 +84,7 @@ In the above example, the ADB service is exposed directly over the internet. Thi
 
 To set up a secure connection, launch the container so that it doesn't expose the ADB service to the internet:
 
-    amc launch -s adb -p swrast -r default
+    amc launch -s adb --enable-graphics -r default
 
 As the ADB service is enabled for the launched container but without the leading `+`, the endpoint 10.226.4.168:10000/tcp shown via `amc ls` is not exposed to the public network:
 

--- a/howto/container/launch.md
+++ b/howto/container/launch.md
@@ -53,9 +53,9 @@ By default, every container is scheduled by AMS onto a LXD node. Alternatively, 
 
 ## Launch a container with a different Anbox platform
 
-By default, every container starts with the `null` platform (see [Anbox platforms](https://discourse.ubuntu.com/t/anbox-platforms/18733)). The selected platform cannot be changed at runtime and must be selected when the container is created. For example, you can launch a container with the `swrast` platform like this:
+By default, containers start with the `webrtc` platform if `--enable-graphics` is specified and with the `null` platform otherwise (see [Anbox platforms](https://discourse.ubuntu.com/t/anbox-platforms/18733)). To select a different platform, specify it with the `-p` flag. The selected platform cannot be changed at runtime and must be selected when the container is created. For example, you can launch a container with the `webrtc` platform like this:
 
-    amc launch -p swrast <application-id>
+    amc launch -p webrtc <application-id>
 
 If you have built your own platform named `foo` and you built it via an addon into the container images, you can launch a container with the platform the same way:
 

--- a/reference/platforms.md
+++ b/reference/platforms.md
@@ -5,19 +5,19 @@ Anbox can make use of different [platforms](https://anbox-cloud.github.io/1.10/a
 | Name     	| Behavior                                                                                                                                            	|
 |----------	|-----------------------------------------------------------------------------------------------------------------------------------------------------	|
 | `null`   	|  A headless-gl platform. No rendering is performed. No audio input/output. Useful for functional tests. It's used by default if no platform is specified when launching a container.                                                                       	|
-| `webrtc` 	| Full-featured WebRTC based streaming platform. Includes driver and integration for AMD and NVidia GPUs as well as LLVMPipe based software rendering if no GPU is detected.  Support audio input/output.	|
-| `swrast` 	| **S**oft**w**are **Rast**erization platform. A LLVMPipe based software rendering platform. Useful for visual tests. No audio input/output.                                                               	|
+| `webrtc` 	| Full-featured WebRTC based streaming platform. Includes driver and integration for AMD and NVidia GPUs as well as LLVMPipe based software rendering if no GPU is detected.  Support audio input/output. |
+| `swrast` 	| (DEPRECATED) **S**oft**w**are **Rast**erization platform. A LLVMPipe based software rendering platform. Useful for visual tests. No audio input/output.                                                               	|
 
 ## Using platforms
 
 Instructing a container to use a platform is done through the `--platform` (or `-p`) flag when launching a container, e.g.
 
-```bash
-amc launch -p swrast <application>
-```
+    amc launch -p webrtc <application>
 
 ### `swrast` platform
 #### Display Settings Configuration
+
+[note type="caution" status="Warning"]The `swrast` platform is deprecated and has been replaced with the `webrtc` platform starting with Anbox Cloud 1.13. You can still explicitly specify `swrast` as platform name, but internally, it is mapped to the `webrtc` platform. The `webrtc` platform provides backward compatibility with the display settings described below.[/note]
 
 Anbox Cloud provides a way of inserting user data to Android container upon its launch which can configure the display settings for swrast platform.
 
@@ -32,16 +32,12 @@ Density         | 160
 
 If you want to change the display settings of Android container, you need to provide a combination of a numeric formatting string as follows:
 
-```
-<Display width>,<Display height>,<FPS>,<Display Density>
-```
+    <Display width>,<Display height>,<FPS>,<Display density>
 
 The first two fields which imply display width and display height respectively are required, however the latter two are optional.
 And when launching a container, supply the display settings via user data:
 
-```bash
-amc launch --userdata="960,720,30,120" -p swrast <application>
-```
+    amc launch --userdata="960,720,30,120" -p swrast <application>
 
 Then the supplied display setting will be applied after the container gets started.
 
@@ -50,8 +46,23 @@ Then the supplied display setting will be applied after the container gets start
 
 Display settings for the `null` can be configured in the same way as for the `swrast` platform.
 
-Instead of supplying the display settings via userdata through the `amc launch` command they can be alternatively written before the start of the Anbox runtime (e.g. in a pre-start hook) to `/var/lib/anbox/display_settings`. The format remains the same as when supplied as userdata.
+Instead of supplying the display settings via userdata through the `amc launch` command they can be alternatively written before the start of the Anbox runtime (e.g. in a `pre-start` hook) to `/var/lib/anbox/display_settings`. The format remains the same as when supplied as userdata.
 
 ### `webrtc` platform
 
-When using the [Stream Gateway](https://discourse.ubuntu.com/t/streaming-android-applications/17769), the `webrtc` platform is automatically used when launching containers. You don't need to perform additional steps. Launching a container with the webrtc platform can be done via the [web dashboard](https://discourse.ubuntu.com/t/web-dashboard/20871).
+The `webrtc` platform is used by Anbox to provide graphical output. It supports all GPUs supported by Anbox Cloud in addition to software rendering. It is used when a container is launched with `--enabled-graphics`, or via the Anbox Stream Gateway.
+
+#### Configuration
+
+The `webrtc` platform can be configured through user data provided to the container in JSON format. AMS puts the configuration data at `/var/lib/anbox/userdata`.
+
+Field name | Type | Default | Description
+-----------|------|---------|------------
+`display_width` | `int` | `1280` | Width of the display provided to Android.
+`display_height` | `int` | `720` | Height of the display provided to Android.
+`display_density` | `int` | `240` | Density of the display provided to Android.
+`fps` | `int` | `60` | Refresh rate of the display provided to Android.
+
+For example, to configure the platform for a display height of 1080p and 60 FPS, set the user data for a container like this:
+
+    amc launch -p webrtc --userdata '{"display_width":1920, "display_height":1080, "fps": 60}'

--- a/tutorial/getting-started.md
+++ b/tutorial/getting-started.md
@@ -135,9 +135,9 @@ See the [`scrcpy` documentation](https://github.com/Genymobile/scrcpy) for insta
 
 To connect to your virtual device with `scrcpy`, complete the following steps:
 
-1. Launch a container based on the virtual device application, with the ADB service exposed and using the [`swrast` platform](https://discourse.ubuntu.com/t/anbox-platforms/18733) that provides software rendering:
+1. Launch a container based on the virtual device application, with the ADB service exposed and graphics enabled: 
 
-        amc launch virtual-device-cli --service +adb --platform swrast
+        amc launch virtual-device-cli --service +adb --enable-graphics
 
 2. Enter the following command to monitor the progress:
 


### PR DESCRIPTION
With 1.13 we're replacing swrast with the webrtc platform but still
providing backward compatibility. Users are now meant to directly start
containers with `--enable-graphics` rather than specifying any platform.