### PR TITLE
Update the `juju deploy` command after migrating to charmcraft

### DIFF
--- a/howto/aar/deploy.md
+++ b/howto/aar/deploy.md
@@ -2,7 +2,7 @@ An [Anbox Application Registry (AAR)](https://discourse.ubuntu.com/t/application
 
 Use the following commands to deploy an AAR:
 
-    juju deploy cs:~anbox-charmers/aar
+    juju deploy cs:~anbox-charmers/aar-95
     juju config aar ua_token=<your UA token>
 
 ## Using the AWS S3 storage backend

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -82,11 +82,11 @@ Choose between the available [Juju bundles](https://discourse.ubuntu.com/t/about
 
 * For a minimised version of Anbox Cloud without the streaming stack, run the following command to deploy the `anbox-cloud-core` bundle:
 
-        juju deploy cs:~anbox-charmers/anbox-cloud-core --overlay ua.yaml --map-machines 0=0,1=1
+        juju deploy cs:~anbox-charmers/anbox-cloud-core-89 --overlay ua.yaml --map-machines 0=0,1=1
 
 * For the full version of Anbox Cloud, run the following command to deploy the `anbox-cloud` bundle:
 
-        juju deploy cs:~anbox-charmers/anbox-cloud --overlay ua.yaml --map-machines 0=0,1=1,2=2
+        juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay ua.yaml --map-machines 0=0,1=1,2=2
 
 You can watch the status of the deployment with the following command:
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -112,11 +112,11 @@ Choose between the available [Juju bundles](https://discourse.ubuntu.com/t/about
 
 * For a minimised version of Anbox Cloud without the streaming stack, run the following command to deploy the `anbox-cloud-core` bundle:
 
-        juju deploy cs:~anbox-charmers/anbox-cloud-core --overlay ua.yaml
+        juju deploy cs:~anbox-charmers/anbox-cloud-core-89 --overlay ua.yaml
 
 * For the full version of Anbox Cloud, run the following command to deploy the `anbox-cloud` bundle:
 
-        juju deploy cs:~anbox-charmers/anbox-cloud --overlay ua.yaml
+        juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay ua.yaml
 
 ## Customise the hardware configuration
 
@@ -151,7 +151,7 @@ machines:
 
 To deploy, add `--overlay overlay.yaml` to your deploy command. For example:
 
-    juju deploy cs:~anbox-charmers/anbox-cloud --overlay ua.yaml --overlay overlay.yaml
+    juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay ua.yaml --overlay overlay.yaml
 
 ### Add GPU support
 
@@ -174,7 +174,7 @@ machines:
 
 To deploy, add `--overlay overlay.yaml` to your deploy command. For example:
 
-    juju deploy cs:~anbox-charmers/anbox-cloud --overlay ua.yaml --overlay overlay.yaml
+    juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay ua.yaml --overlay overlay.yaml
 
 ### Use Arm instances
 
@@ -195,7 +195,7 @@ machines:
 
 To deploy, add `--overlay overlay.yaml` to your deploy command. For example:
 
-    juju deploy cs:~anbox-charmers/anbox-cloud --overlay ua.yaml --overlay overlay.yaml
+    juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay ua.yaml --overlay overlay.yaml
 
 ## Monitor the deployment
 

--- a/howto/install/high-availability.md
+++ b/howto/install/high-availability.md
@@ -28,7 +28,7 @@ This is heavily recommended on production environments.[/note]
 Anbox Cloud Core HA requires additional AMS instances as well as a load balancer to spread out requests:
 
 ```bash
-$ juju deploy cs:~anbox-charmers/ams-load-balancer
+$ juju deploy cs:~anbox-charmers/ams-load-balancer-99
 $ juju relate ams ams-load-balancer
 $ juju add-unit ams -n 2
 ```

--- a/howto/monitor/collect-metrics.md
+++ b/howto/monitor/collect-metrics.md
@@ -194,11 +194,11 @@ Complete the following steps to deploy Anbox Cloud with the reference monitoring
 
    - For the `anbox-cloud-core` bundle:
 
-         juju deploy cs:~anbox-charmers/anbox-cloud-core --overlay monitoring.yaml
+         juju deploy cs:~anbox-charmers/anbox-cloud-core-89 --overlay monitoring.yaml
 
    - For the `anbox-cloud` bundle:
 
-         juju deploy cs:~anbox-charmers/anbox-cloud --overlay monitoring.yaml
+         juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay monitoring.yaml
 
    [note type="information" status="Note"]You can use the same command if you already deployed Anbox Cloud. In this case, Juju checks the existing deployment and only deploys new components.[/note]
 1. Wait until all added units are in `active` state.

--- a/howto/monitor/monitor-status.md
+++ b/howto/monitor/monitor-status.md
@@ -91,11 +91,11 @@ Complete the following steps to deploy Anbox Cloud with the reference monitoring
 
    - For the `anbox-cloud-core` bundle:
 
-         juju deploy cs:~anbox-charmers/anbox-cloud-core --overlay nagios.yaml
+         juju deploy cs:~anbox-charmers/anbox-cloud-core-89 --overlay nagios.yaml
 
    - For the `anbox-cloud` bundle:
 
-         juju deploy cs:~anbox-charmers/anbox-cloud --overlay nagios.yaml
+         juju deploy cs:~anbox-charmers/anbox-cloud-103 --overlay nagios.yaml
 
    [note type="information" status="Note"]You can use the same command if you already deployed Anbox Cloud. In this case, Juju checks the existing deployment and only deploys new components.[/note]
 1. Wait until all added units are in `active` state.


### PR DESCRIPTION
\With juju 2.9, deploying Anbox Cloud with the following syntax doesn't
work anymore
 ```
 juju deploy cs:~anbox-charmers/<charm_name>
 ```
 and people have to add the revision number to the charm name to get
 things work properly.
    
 We stick to `cs:` way of addressing charms ahead for deployment
 before switching to use the flat name for charms and bundles.