### PR TITLE
update spelling wordlist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -5,7 +5,6 @@ AAR
 AArch
 ABI
 ABIs
-adb
 ADB
 addon
 addons
@@ -97,7 +96,6 @@ Graviton
 gzip
 HAProxy
 https
-hwcomposer
 HWE
 IAM
 IDR
@@ -233,13 +231,11 @@ validator
 vCPU
 vCPUs
 viewport
-wl
 VMs
 VNC
 VPC
 Vulkan
 Wayland
-webrtc
 WebRTC
 WebView
 WGS

--- a/announcements/1.13.2.md
+++ b/announcements/1.13.2.md
@@ -32,12 +32,12 @@ will be also visually applied to the HTML element containing the stream video. W
 * AC-830 On a multi GPU system default number of slots is split across all GPUs
 * AC-829 AMS leaks ports for already removed containers
 * AC-828 Changing the parent image of an application in AMS returns with error
-* AC-811 Anbox hwcomposer crashes on highly loaded system with wl_abort
-* AC-809 Empty device name is shown up when running adb shell getevent
+* AC-811 Anbox `hwcomposer` crashes on highly loaded system with `wl_abort`
+* AC-809 Empty device name is shown up when running `adb shell getevent`
 * AC-788 DrArm is showing just a black screen
 * AC-782 Add support for missing GL parameter sizes
 * AC-765 Minetest crashes on 1.13.0 with SEGV in Anbox
-* AC-725 A segfault occurred from the webrtc stack during the anbox session runtime
+* AC-725 A segfault occurred from the WebRTC stack during the anbox session runtime
 * AC-646 1.12 hooks: $CONTAINER_TYPE is empty for regular containers
 * AC-827 Failed to create an arm64 based application when Anbox Cloud deployment is capable with multiple architectures
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -23,12 +23,12 @@ n/a
 * AC-830 On a multi GPU system default number of slots is split across all GPUs
 * AC-829 AMS leaks ports for already removed containers
 * AC-828 Changing the parent image of an application in AMS returns with error
-* AC-811 Anbox hwcomposer crashes on highly loaded system with wl_abort
-* AC-809 Empty device name is shown up when running adb shell getevent
+* AC-811 Anbox `hwcomposer` crashes on highly loaded system with `wl_abort`
+* AC-809 Empty device name is shown up when running `adb shell getevent`
 * AC-788 DrArm is showing just a black screen
 * AC-782 Add support for missing GL parameter sizes
 * AC-765 Minetest crashes on 1.13.0 with SEGV in Anbox
-* AC-725 A segfault occurred from the webrtc stack during the anbox session runtime
+* AC-725 A segfault occurred from the WebRTC stack during the anbox session runtime
 * AC-646 1.12 hooks: $CONTAINER_TYPE is empty for regular containers
 * AC-827 Failed to create an arm64 based application when Anbox Cloud deployment is capable with multiple architectures
 


### PR DESCRIPTION
The wordlist should only contain actual words.
Commands/components/modules/functions and so on should be formatted
as code in the text (which will exclude them from spellchecking).

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>