### PR TITLE
change link text to reflect topic titles

### DIFF
--- a/exp/aar.md
+++ b/exp/aar.md
@@ -20,6 +20,6 @@ A single AMS instance can act only as a publisher or as a client, but not both. 
 
 See the following documentation for instructions on how to use the AAR:
 
-* [Deploy an AAR](https://discourse.ubuntu.com/t/installation-application-registry/17749)
-* [Configure an AAR](https://discourse.ubuntu.com/t/configure-an-aar/24319)
-* [Revoke an AAR client](https://discourse.ubuntu.com/t/revoke-an-aar-client/24320)
+* [How to deploy an AAR](https://discourse.ubuntu.com/t/installation-application-registry/17749)
+* [How to configure an AAR](https://discourse.ubuntu.com/t/configure-an-aar/24319)
+* [How to revoke an AAR client](https://discourse.ubuntu.com/t/revoke-an-aar-client/24320)

--- a/exp/ams.md
+++ b/exp/ams.md
@@ -47,4 +47,4 @@ You can access AMS either by IP or through a UNIX socket. The IP depends on your
 
 ## Remote access to AMS
 
-See [Control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) for instructions on how to set up an Anbox Management Client on a separate machine and configure it to remotely connect to AMS.
+See [How to control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) for instructions on how to set up an Anbox Management Client on a separate machine and configure it to remotely connect to AMS.

--- a/exp/anbox-cloud.md
+++ b/exp/anbox-cloud.md
@@ -90,4 +90,4 @@ The regular Anbox Cloud variant provides two different Juju bundles:
 
 [note type="information" status="Tip"]For detailed information about the charm, check the `bundle.yaml` file in the bundle. You can download the bundle with `juju download <charm_name>`, thus `juju download anbox-charmers-anbox-cloud-core` or `juju download anbox-charmers-anbox-cloud`. Unzip the bundle to access the `bundle.yaml` file.[/note]
 
-If you don't need to stream the visual output of the Android containers, you can use the `anbox-cloud-core` bundle. Otherwise, you should use the `anbox-cloud` bundle. However, even without the streaming stack, there are still ways to get visual access for inspection purposes. See [Access a container](https://discourse.ubuntu.com/t/container-access/17772) for details.
+If you don't need to stream the visual output of the Android containers, you can use the `anbox-cloud-core` bundle. Otherwise, you should use the `anbox-cloud` bundle. However, even without the streaming stack, there are still ways to get visual access for inspection purposes. See [How to access a container](https://discourse.ubuntu.com/t/container-access/17772) for details.

--- a/exp/applications.md
+++ b/exp/applications.md
@@ -76,11 +76,11 @@ When the application bootstrap succeeds, the base container is automatically rem
 
 See the following documentation for instructions on how to manage your applications:
 
- * [Create an application](https://discourse.ubuntu.com/t/create-an-application/24198)
- * [Wait for an application](https://discourse.ubuntu.com/t/wait-for-an-application/24202)
- * [Update an application](https://discourse.ubuntu.com/t/update-an-application/24201)
- * [Configure available resources](https://discourse.ubuntu.com/t/configure-available-resources/24960)
- * [Delete an application](https://discourse.ubuntu.com/t/delete-an-application/24199)
- * [List applications](https://discourse.ubuntu.com/t/list-applications/24200)
- * [Test your application](https://discourse.ubuntu.com/t/usecase-application-testing/17775)
- * [Create a virtual device](https://discourse.ubuntu.com/t/virtual-devices/19069)
+ * [How to create an application](https://discourse.ubuntu.com/t/create-an-application/24198)
+ * [How to wait for an application](https://discourse.ubuntu.com/t/wait-for-an-application/24202)
+ * [How to update an application](https://discourse.ubuntu.com/t/update-an-application/24201)
+ * [How to configure available resources](https://discourse.ubuntu.com/t/configure-available-resources/24960)
+ * [How to delete an application](https://discourse.ubuntu.com/t/delete-an-application/24199)
+ * [How to list applications](https://discourse.ubuntu.com/t/list-applications/24200)
+ * [How to test your application](https://discourse.ubuntu.com/t/usecase-application-testing/17775)
+ * [How to create a virtual device](https://discourse.ubuntu.com/t/virtual-devices/19069)

--- a/exp/clustering.md
+++ b/exp/clustering.md
@@ -124,7 +124,7 @@ The following guidelines are both recommended and must-have aspects of an auto s
 
 ### Scaling up or down
 
-See [Scale up a LXD cluster](https://discourse.ubuntu.com/t/scale-up-a-lxd-cluster/24322) and [Scale down a LXD cluster](https://discourse.ubuntu.com/t/scale-down-a-lxd-cluster/24323) for instructions on how to add or remove nodes from the cluster.
+See [How to scale up a LXD cluster](https://discourse.ubuntu.com/t/scale-up-a-lxd-cluster/24322) and [How to scale down a LXD cluster](https://discourse.ubuntu.com/t/scale-down-a-lxd-cluster/24323) for instructions on how to add or remove nodes from the cluster.
 
 ## When to scale up or down the cluster?
 

--- a/exp/containers.md
+++ b/exp/containers.md
@@ -66,12 +66,12 @@ Status            |  Description
 
 ## Managing containers
 
- * [Launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327)
- * [Wait for a container](https://discourse.ubuntu.com/t/wait-for-a-container/24330)
- * [Access a container](https://discourse.ubuntu.com/t/access-containers-remotely/17772)
- * [Expose services on a container](https://discourse.ubuntu.com/t/expose-services-on-a-container/24326)
- * [View the container logs](https://discourse.ubuntu.com/t/view-the-container-logs/24329)
- * [Delete a container](https://discourse.ubuntu.com/t/delete-a-container/24325)
- * [List containers](https://discourse.ubuntu.com/t/list-containers/24328)
- * [Configure geographic location](https://discourse.ubuntu.com/t/usecase-container-configuration/17782)
- * [Back up and restore application data](https://discourse.ubuntu.com/t/back-up-and-restore-application-data/24183)
+ * [How to launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327)
+ * [How to wait for a container](https://discourse.ubuntu.com/t/wait-for-a-container/24330)
+ * [How to access a container](https://discourse.ubuntu.com/t/access-containers-remotely/17772)
+ * [How to expose services on a container](https://discourse.ubuntu.com/t/expose-services-on-a-container/24326)
+ * [How to view the container logs](https://discourse.ubuntu.com/t/view-the-container-logs/24329)
+ * [How to delete a container](https://discourse.ubuntu.com/t/delete-a-container/24325)
+ * [How to list containers](https://discourse.ubuntu.com/t/list-containers/24328)
+ * [How to configure geographic location](https://discourse.ubuntu.com/t/usecase-container-configuration/17782)
+ * [How to back up and restore application data](https://discourse.ubuntu.com/t/back-up-and-restore-application-data/24183)

--- a/howto/addons/landing.md
+++ b/howto/addons/landing.md
@@ -1,10 +1,10 @@
 Addons can be used to customise the images used for the containers. An addon has [hooks](https://discourse.ubuntu.com/t/addons/25293#hooks) that are invoked at various points in the life cycle of a container. Addons are created independently and can be attached to individual applications.
 
-See [Addons](https://discourse.ubuntu.com/t/addons/25293) for more information and a complete reference on addons. Follow the [Creating an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284) tutorial to learn how to write a simple addon.
+See [Addons](https://discourse.ubuntu.com/t/addons/25293) for more information and a complete reference on addons. Follow the [Create an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284) tutorial to learn how to write a simple addon.
 
 You can use addons to, for example:
-- Enable SSH access for automation tools (see [Creating an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284))
-- Set up user-specific data when starting an application (see [Restore data](https://discourse.ubuntu.com/t/example-back-up-data/25289#restore))
+- Enable SSH access for automation tools (see [Create an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284))
+- Set up user-specific data when starting an application (see [How to restore data](https://discourse.ubuntu.com/t/example-back-up-data/25289#restore))
 - Install additional tools in the container (see [Example: Install tools](https://discourse.ubuntu.com/t/example-install-tools/25288))
 - Back up data when the container is stopping (see [Example: Back up data](https://discourse.ubuntu.com/t/example-back-up-data/25289))
 - Configure the Android system before running the application (see [Example: Customise Android](https://discourse.ubuntu.com/t/example-customise-android/25290))

--- a/howto/application/create.md
+++ b/howto/application/create.md
@@ -102,7 +102,7 @@ resources:
   disk-size: 8GB
 ```
 
-Once the status of the application switches to `ready`, the application is ready and can be used. See [Wait for an application](https://discourse.ubuntu.com/t/wait-for-an-application/24202) for information about how to monitor the application status.
+Once the status of the application switches to `ready`, the application is ready and can be used. See [How to wait for an application](https://discourse.ubuntu.com/t/wait-for-an-application/24202) for information about how to monitor the application status.
 
 ## Create from a tarball
 
@@ -118,4 +118,4 @@ Once the tarball is created, you can create the application:
 
     amc application create foo.tar.bz2
 
-The AMS service now starts the application [bootstrap process](https://discourse.ubuntu.com/t/managing-applications/17760#bootstrap). See [Wait for an application](https://discourse.ubuntu.com/t/wait-for-an-application/24202) for information about how to monitor the application status.
+The AMS service now starts the application [bootstrap process](https://discourse.ubuntu.com/t/managing-applications/17760#bootstrap). See [How to wait for an application](https://discourse.ubuntu.com/t/wait-for-an-application/24202) for information about how to monitor the application status.

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -16,9 +16,9 @@ This will create a container which exposes the TCP port `5559` on its private ad
 $ amc launch -s +adb --enable-graphics -r
 ```
 
-[note type="information" status="Hint"]If you're wondering about the syntax of the command used to launch a container, see [Launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327).[/note]
+[note type="information" status="Hint"]If you're wondering about the syntax of the command used to launch a container, see [How to launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327).[/note]
 
-If you want to run the Appium tests against an Android application managed by AMS (see [Create an application](https://discourse.ubuntu.com/t/create-an-application/24198)) you can start a regular container instead:
+If you want to run the Appium tests against an Android application managed by AMS (see [How to create an application](https://discourse.ubuntu.com/t/create-an-application/24198)) you can start a regular container instead:
 
 ```bash
 $ amc launch -s adb --enable-graphics --disable-watchdog app

--- a/howto/application/virtual-devices.md
+++ b/howto/application/virtual-devices.md
@@ -70,6 +70,6 @@ The application will now include the [Lawnchair](https://lawnchair.app/) and has
 
 ## Launching the new Application
 
-Now that we have the application created in AMS we can go ahead and stream it through the UI of the Anbox Stream Gateway (see [Getting started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) for more details) or your own custom client application built with the [Anbox Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk).
+Now that we have the application created in AMS we can go ahead and stream it through the UI of the Anbox Stream Gateway (see [Get started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) for more details) or your own custom client application built with the [Anbox Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk).
 
 ![Virtual device|690x662,100%](https://assets.ubuntu.com/v1/4cc5a115-application_virtual-device.png)

--- a/howto/container/launch.md
+++ b/howto/container/launch.md
@@ -1,6 +1,6 @@
 You can launch a container for a registered application or image (see [Application containers vs. raw containers](https://discourse.ubuntu.com/t/managing-containers/17763#application-vs-raw)), either by using the `amc` tool or through another service over the REST API that the AMS service provides.
 
-By default, the container will run headless. See [Access a container](https://discourse.ubuntu.com/t/container-access/17772) for instructions on how to access it for debugging purposes, and [About application streaming](https://discourse.ubuntu.com/t/streaming-android-applications/17769) for information about the streaming stack.
+By default, the container will run headless. See [How to access a container](https://discourse.ubuntu.com/t/container-access/17772) for instructions on how to access it for debugging purposes, and [About application streaming](https://discourse.ubuntu.com/t/streaming-android-applications/17769) for information about the streaming stack.
 
 <a name="application-containers"></a>
 ## Launch application containers

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -1,4 +1,4 @@
-To deploy Anbox Cloud on a public cloud (such as AWS, Azure or Google) or using MAAS or OpenStack, see the instructions in [Deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/deploy-anbox-cloud-with-juju/17744).
+To deploy Anbox Cloud on a public cloud (such as AWS, Azure or Google) or using MAAS or OpenStack, see the instructions in [How to deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/deploy-anbox-cloud-with-juju/17744).
 
 Alternatively, you can follow the instructions in this document to use the [manual cloud provider](https://jaas.ai/docs/manual-cloud) that Juju offers. This method allows you to deploy Anbox Cloud with Juju on a set of SSH connected machines.
 
@@ -54,7 +54,7 @@ Juju will add the machines to its list of usable machines, which you can display
 
 ## Attach your Ubuntu Advantage subscription
 
-Create an `ua.yaml` overlay file as described in [Deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/deploy-anbox-cloud-with-juju/17744#ua-overlay).
+Create an `ua.yaml` overlay file as described in [How to deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/deploy-anbox-cloud-with-juju/17744#ua-overlay).
 
 You must provide this file when deploying Anbox Cloud.
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -1,9 +1,9 @@
 Anbox Cloud supports various public clouds, such as AWS, Azure and Google. To deploy Anbox Cloud in a cloud environment, you use Juju.
 
-See the following sections for detailed instructions. If you want to install Anbox Cloud on bare metal instead of a public cloud, see [Deploy Anbox Cloud on bare metal](https://discourse.ubuntu.com/t/deploy-anbox-cloud-on-bare-metal/26378) instead.
+See the following sections for detailed instructions. If you want to install Anbox Cloud on bare metal instead of a public cloud, see [How to deploy Anbox Cloud on bare metal](https://discourse.ubuntu.com/t/deploy-anbox-cloud-on-bare-metal/26378) instead.
 
 [note type="information" status="Note"]
-There are differences between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [Installing the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).
+There are differences between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [Install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).
 [/note]
 
 ## Prerequisites

--- a/howto/install/landing.md
+++ b/howto/install/landing.md
@@ -1,5 +1,5 @@
 The guides in this section describe how to install Anbox Cloud.
 
-[note type="information" status="Note"]There is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [Installing the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).[/note]
+[note type="information" status="Note"]There is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [Install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).[/note]
 
 Make sure to check the [Requirements](https://discourse.ubuntu.com/t/installation-requirements/17734) before you start your installation.

--- a/howto/install/validate.md
+++ b/howto/install/validate.md
@@ -84,7 +84,7 @@ suites:
         gpu-type: none
 ```
 
-As mentioned by the command you have to store the printed configuration to a file so it can be used by the tests later on. Also you need to register the generated TLS certificate for the AMS tests with AMS. See [Control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) for more details on how to do that.
+As mentioned by the command you have to store the printed configuration to a file so it can be used by the tests later on. Also you need to register the generated TLS certificate for the AMS tests with AMS. See [How to control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) for more details on how to do that.
 
 Depending on your deployment you can further customise the generated configuration. For example may your deployment only support a single architecture for the containers. For that make sure the `suites.ams.supported-architectures` field is set to the right list of architectures.
 

--- a/howto/manage/benchmarks.md
+++ b/howto/manage/benchmarks.md
@@ -127,7 +127,7 @@ Check the help output to see all available arguments and their purpose:
 
     anbox-cloud-tests.benchmark -h
 
-To run the benchmark, you must provide an authentication token for the Anbox Stream Gateway. Check [Access the stream gateway](https://discourse.ubuntu.com/t/managing-stream-gateway-access/17784) if you haven't already created an authentication token.
+To run the benchmark, you must provide an authentication token for the Anbox Stream Gateway. Check [How to access the stream gateway](https://discourse.ubuntu.com/t/managing-stream-gateway-access/17784) if you haven't already created an authentication token.
 
 If your Anbox Stream Gateway is behind a self-signed TLS certificate, you must specify the `--insecure-tls` option.
 

--- a/howto/manage/logs.md
+++ b/howto/manage/logs.md
@@ -1,6 +1,6 @@
 There are two types of logs that help you understand what is happening in your Anbox Cloud installation:
 
-- Logs for the applications that you are running, on a cluster or node level. See [View the container logs](https://discourse.ubuntu.com/t/view-the-container-logs/24329) for information about this type of logs.
+- Logs for the applications that you are running, on a cluster or node level. See [How to view the container logs](https://discourse.ubuntu.com/t/view-the-container-logs/24329) for information about this type of logs.
 - Infrastructure logs for the deployment. These logs differ depending on whether you run a full Anbox Cloud deployment or the Anbox Cloud Appliance. See the following sections for more information.
 
 ## View logs for Anbox Cloud

--- a/howto/manage/manage-appliance.md
+++ b/howto/manage/manage-appliance.md
@@ -6,7 +6,7 @@ The available commands for the `anbox-cloud-appliance` tool are:
 
 - `ams`
 
-  Expose the AMS HTTPS service on the public endpoint of the machine on which the appliance is running. If you do this, you can [Control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774).
+  Expose the AMS HTTPS service on the public endpoint of the machine on which the appliance is running. If you do this, you can [control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774).
 - `crashdump`
 
   Generate a tarball that contains debug information.
@@ -20,7 +20,7 @@ The available commands for the `anbox-cloud-appliance` tool are:
   [note type="caution" status="Warning"]This command resets the Anbox Cloud Appliance and destroys all data. Execution of the command cannot be undone.[/note]
 - `gateway`
 
-  Expose or unexpose the HTTP API of the stream gateway and manage access to it. If the HTTP API is exposed (which is the default), authenticated clients can connect to it. Authentication requires an access token that you can create with the `anbox-cloud-appliance gateway account create` command. See [Access the stream gateway](https://discourse.ubuntu.com/t/managing-stream-gateway-access/17784) for more information.
+  Expose or unexpose the HTTP API of the stream gateway and manage access to it. If the HTTP API is exposed (which is the default), authenticated clients can connect to it. Authentication requires an access token that you can create with the `anbox-cloud-appliance gateway account create` command. See [How to access the stream gateway](https://discourse.ubuntu.com/t/managing-stream-gateway-access/17784) for more information.
 - `help`
 
   Display detailed information about a command.
@@ -35,4 +35,4 @@ The available commands for the `anbox-cloud-appliance` tool are:
   Display status information for the Anbox Cloud Appliance.
 - `upgrade`
 
-  Upgrade the Anbox Cloud Appliance to the latest version. See [Upgrade the appliance](https://discourse.ubuntu.com/t/upgrade-anbox-cloud-appliance/24186) for more information.
+  Upgrade the Anbox Cloud Appliance to the latest version. See [How to upgrade the appliance](https://discourse.ubuntu.com/t/upgrade-anbox-cloud-appliance/24186) for more information.

--- a/howto/manage/web-dashboard.md
+++ b/howto/manage/web-dashboard.md
@@ -48,7 +48,7 @@ unit-anbox-cloud-dashboard-0:
 <a name="dashboard-access-appliance"></a>
 #### Register a Ubuntu One account in Anbox Cloud Appliance
 
-If you followed the instructions in [Installing the appliance](https://discourse.ubuntu.com/t/install-appliance/22681) to install the Anbox Cloud Appliance, you already registered your Ubuntu One account.
+If you followed the instructions in [Install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681) to install the Anbox Cloud Appliance, you already registered your Ubuntu One account.
 
 To add more accounts, use the following command:
 
@@ -60,7 +60,7 @@ The generated link is valid for one hour.
 
 ### Creating applications
 
-Creating applications through the dashboard is done the same way as you would do with `amc` (see [Create an application](https://discourse.ubuntu.com/t/create-an-application/24198)).
+Creating applications through the dashboard is done the same way as you would do with `amc` (see [How to create an application](https://discourse.ubuntu.com/t/create-an-application/24198)).
 Note that more advanced scenarios might not yet be possible via the dashboard and require going through `amc`.
 
 ![Create an application|690x438](https://assets.ubuntu.com/v1/40dda4a6-manage_dashboard-add-application.png)

--- a/howto/port/landing.md
+++ b/howto/port/landing.md
@@ -1,8 +1,8 @@
 When porting an Android app to Anbox Cloud (usually in the form of an APK), there are a few issues that might cause your app to not function properly:
 
 * Missing dependencies, most importantly to Google Play services. Google Play services are not supported by Anbox Cloud, and apps that require Google Play services can therefore not be ported to Anbox Cloud.
-* Missing runtime permissions. See [Grant runtime permissions](https://discourse.ubuntu.com/t/grant-runtime-permissions/26054) for instructions on how to grant the required permissions.
-* Mismatched architecture. See [Choose APK architecture](https://discourse.ubuntu.com/t/choose-apk-architecture/26055) for information on which architecture you should choose.
-* App size. See [Port APKs with OBB files](https://discourse.ubuntu.com/t/port-apks-with-obb-files/26056) for instructions on how to port large APKs.
-* Strict watchdog restrictions. See [Configure the watchdog](https://discourse.ubuntu.com/t/configure-the-watchdog/26057) if you want to turn the watchdog off for debugging or configure it to not trigger for specific apps.
-* Install an APK as a system app. See [Install an APK as a system app](https://discourse.ubuntu.com/t/install-an-apk-as-a-system-app/27086) if you want to install a user app as a system app running in an Android container.
+* Missing runtime permissions. See [How to grant runtime permissions](https://discourse.ubuntu.com/t/grant-runtime-permissions/26054) for instructions on how to grant the required permissions.
+* Mismatched architecture. See [How to choose APK architecture](https://discourse.ubuntu.com/t/choose-apk-architecture/26055) for information on which architecture you should choose.
+* App size. See [How to port APKs with OBB files](https://discourse.ubuntu.com/t/port-apks-with-obb-files/26056) for instructions on how to port large APKs.
+* Strict watchdog restrictions. See [How to configure the watchdog](https://discourse.ubuntu.com/t/configure-the-watchdog/26057) if you want to turn the watchdog off for debugging or configure it to not trigger for specific apps.
+* Install an APK as a system app. See [How to install an APK as a system app](https://discourse.ubuntu.com/t/install-an-apk-as-a-system-app/27086) if you want to install a user app as a system app running in an Android container.

--- a/howto/stream/landing.md
+++ b/howto/stream/landing.md
@@ -1,5 +1,5 @@
 The guides in this section describe how to use the Streaming Stack to implement specific streaming features in your application.
 
-See [Streaming Android Applications](https://discourse.ubuntu.com/t/streaming-android-applications/17769) for an introduction to the Streaming Stack.
+See [About application streaming](https://discourse.ubuntu.com/t/streaming-android-applications/17769) for an introduction to the Streaming Stack.
 
 For an introduction to the Streaming SDK, see [Anbox Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk).

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -46,7 +46,7 @@ The following issues should help you determining why your container failed.
 
 If a container fails to start, its status is set to `error`. AMS automatically fetches several log files from the container and makes them available for further inspection. From the log files, you can find out what went wrong. The reason is not always straightforward, because several things play into the container startup, for example, the application that the container is hosting or any installed addons.
 
-See [View the container logs](https://discourse.ubuntu.com/t/view-the-container-logs/24329) for instructions on how to access the container log files.
+See [How to view the container logs](https://discourse.ubuntu.com/t/view-the-container-logs/24329) for instructions on how to access the container log files.
 
 ### Published application version not found
 
@@ -54,7 +54,7 @@ See [View the container logs](https://discourse.ubuntu.com/t/view-the-container-
 
 > When launching a container for an application, I get an error about the "published application version not found". Why?
 
-If you launch a container by only specifying the application ID and the application has no published version yet, you must explicitly specify the version that you want to launch or publish a version of the application. See [Launch application containers](https://discourse.ubuntu.com/t/launch-a-container/24327#application-containers) and [Publish application versions](https://discourse.ubuntu.com/t/update-an-application/24201#publish-application-versions) for more information.
+If you launch a container by only specifying the application ID and the application has no published version yet, you must explicitly specify the version that you want to launch or publish a version of the application. See [How to launch application containers](https://discourse.ubuntu.com/t/launch-a-container/24327#application-containers) and [How to publish application versions](https://discourse.ubuntu.com/t/update-an-application/24201#publish-application-versions) for more information.
 
 ## Creating applications
 

--- a/index.md
+++ b/index.md
@@ -17,9 +17,9 @@ See the [official Anbox Cloud website](https://anbox-cloud.io/) for more informa
 |--|--|
 | [About Anbox Cloud](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802) | Learn about the differences between Anbox Cloud and the Anbox Cloud Appliance and about the components and architecture of the offering |
 | [About AMS](https://discourse.ubuntu.com/t/about-ams/24321) | Understand the Anbox Management Service (AMS), which handles all aspects of the application and container life cycle |
-| [Installing the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681) | Install the Anbox Cloud Appliance, which is well suited for initial prototype and small scale deployments |
-| [Deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/install-with-juju/17744) | Deploy the full Anbox Cloud solution to a public cloud |
-| [Getting started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958)<br>[Getting started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) | Go through the first steps of launching and accessing an Android container to familiarise yourself with Anbox Cloud, by using either the web dashboard or the command line interface |
+| [Install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681) | Install the Anbox Cloud Appliance, which is well suited for initial prototype and small scale deployments |
+| [How to deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/install-with-juju/17744) | Deploy the full Anbox Cloud solution to a public cloud |
+| [Get started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958)<br>[Get started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) | Go through the first steps of launching and accessing an Android container to familiarise yourself with Anbox Cloud, by using either the web dashboard or the command line interface |
 
 
 ## What's new
@@ -40,10 +40,10 @@ Along with bug fixes and general improvements, Anbox Cloud 1.13 comes with:
 | Level | Path | Navlink |
 | -- | -- | -- |
 | 0 | | Tutorials |
-| 1 | tut/installing-appliance | [Installing the appliance](https://discourse.ubuntu.com/t/install-appliance/22681) |
-| 1 | tut/getting-started-dashboard | [Getting started (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958)|
-| 1 | tut/getting-started | [Getting started (CLI)](https://discourse.ubuntu.com/t/getting-started/17756)|
-| 1 | tut/creating-addon | [Creating an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284)|
+| 1 | tut/installing-appliance | [Install the appliance](https://discourse.ubuntu.com/t/install-appliance/22681) |
+| 1 | tut/getting-started-dashboard | [Get started (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958)|
+| 1 | tut/getting-started | [Get started (CLI)](https://discourse.ubuntu.com/t/getting-started/17756)|
+| 1 | tut/creating-addon | [Create an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284)|
 | 0 | | How to |
 | 1 | howto/install/landing | [Install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336)|
 | 2 | howto/install/deploy-juju | [Deploy with Juju](https://discourse.ubuntu.com/t/install-with-juju/17744) |

--- a/ref/addons.md
+++ b/ref/addons.md
@@ -1,4 +1,4 @@
-Addons provide a way to extend and customise images in Anbox Cloud. See [Use addons](https://discourse.ubuntu.com/t/managing-addons/17759) and the [Creating an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284) tutorial for instructions on how to use them.
+Addons provide a way to extend and customise images in Anbox Cloud. See [How to use addons](https://discourse.ubuntu.com/t/managing-addons/17759) and the [Create an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284) tutorial for instructions on how to use them.
 
 <a name='file-structure'></a>
 ## File structure

--- a/ref/ams-http-api.md
+++ b/ref/ams-http-api.md
@@ -284,7 +284,7 @@ For an addon upload, the `X-AMS-Request` header is comprised of:
 }
 ```
 
-The payload to upload must be a tarball compressed with bzip2. Also, it must contain a `manifest.yaml` which declares the basic addon information and at least an install hook for the creation. For the layout addon tarball file and supported syntax, please refer to [addon creation](https://discourse.ubuntu.com/t/managing-addons/17759) for more details.
+The payload to upload must be a tarball compressed with bzip2. Also, it must contain a `manifest.yaml` which declares the basic addon information and at least an install hook for the creation. For the layout addon tarball file and supported syntax, please refer to [How to use addons](https://discourse.ubuntu.com/t/managing-addons/17759) for more details.
 
 Example:
 ```bash
@@ -547,7 +547,7 @@ In the HTTP application upload case, the following headers may be set by the cli
 * `Content-Type:`: application/octet-stream (mandatory field)
 * `X-AMS-Fingerprint:`: SHA-256 (if set, the uploaded payload must match)
 
-The payload to upload must be a tarball compressed with bzip2. Also it must contain a `manifest.yaml` which declares the basic application information for the creation. For the layout application tarball file and supported syntax, see [Create an application](https://discourse.ubuntu.com/t/create-an-application/24198) for more details.
+The payload to upload must be a tarball compressed with bzip2. Also it must contain a `manifest.yaml` which declares the basic application information for the creation. For the layout application tarball file and supported syntax, see [How to create an application](https://discourse.ubuntu.com/t/create-an-application/24198) for more details.
 To support the following syntax in the application `manifest.yaml`, the server requires a corresponding extension
 
 Syntax in manifest            |   Extension

--- a/ref/application-manifest.md
+++ b/ref/application-manifest.md
@@ -21,7 +21,7 @@ Name          | Value type | Description
 
 ## Image
 
-The `image` attribute defines which image the application is based on. If left empty, your application is based on the default image. See [Manage images](https://discourse.ubuntu.com/t/managing-images/17758) for more details on this. Available images on your installation can be listed with the following command:
+The `image` attribute defines which image the application is based on. If left empty, your application is based on the default image. See [How to manage images](https://discourse.ubuntu.com/t/managing-images/17758) for more details on this. Available images on your installation can be listed with the following command:
 
     amc image list
 

--- a/ref/perf-benchmarks.md
+++ b/ref/perf-benchmarks.md
@@ -1,6 +1,6 @@
 The following benchmarks give an overview of the performance that you can achieve with Anbox Cloud.
 
-The benchmarks were performed using the `amc benchmark` utility as described in [Run benchmarks](https://discourse.ubuntu.com/t/benchmarking-a-deployment/17770). The results describe the maximum number of parallel running containers (column "# Containers") delivering a stable frame rate (column "Avg. FPS"). Running more containers either gives too high variation in the provided frame rate or is not possible due to other hardware limitations (system memory, GPU memory, ...).
+The benchmarks were performed using the `amc benchmark` utility as described in [How to run benchmarks](https://discourse.ubuntu.com/t/benchmarking-a-deployment/17770). The results describe the maximum number of parallel running containers (column "# Containers") delivering a stable frame rate (column "Avg. FPS"). Running more containers either gives too high variation in the provided frame rate or is not possible due to other hardware limitations (system memory, GPU memory, ...).
 
 All benchmarks include rendering and video encoding. On machines/VMs without a GPU, rendering and video encoding are performed in software on the CPU.
 

--- a/ref/prometheus.md
+++ b/ref/prometheus.md
@@ -1,4 +1,4 @@
-Anbox Cloud gathers various performance metrics that you can access through API endpoints to create a monitoring solution. See [Monitor Anbox Cloud](https://discourse.ubuntu.com/t/monitor-anbox-cloud/24338) for detailed information.
+Anbox Cloud gathers various performance metrics that you can access through API endpoints to create a monitoring solution. See [How to monitor Anbox Cloud](https://discourse.ubuntu.com/t/monitor-anbox-cloud/24338) for detailed information.
 
 The reference implementation for Prometheus (see [Example: Collect metrics](https://discourse.ubuntu.com/t/example-collect-metrics/17787)) provides some basic dashboards. You can, however, update them to fit your needs.
 

--- a/ref/sdks.md
+++ b/ref/sdks.md
@@ -49,7 +49,7 @@ The AMS SDK comes with a set of examples demonstrating the capabilities of the S
 
 ### Authentication setup
 
-Clients must authenticate to AMS before communicating with it. For more information, see [Control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) and the [AMS SDK documentation](https://github.com/anbox-cloud/ams-sdk) on GitHub.
+Clients must authenticate to AMS before communicating with it. For more information, see [How to control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774) and the [AMS SDK documentation](https://github.com/anbox-cloud/ams-sdk) on GitHub.
 
 <a name="streaming-sdk"></a>
 ## Anbox Streaming SDK

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 [note type="information" status="Note"]If you're interested in getting notified for the latest Anbox Cloud releases, make sure you subscribe to notifications on the [announcements category](https://discourse.ubuntu.com/c/anbox-cloud/announcements/55) on the Anbox Cloud discourse.[/note]
 
-See [Upgrade Anbox Cloud](https://discourse.ubuntu.com/t/upgrading-from-previous-versions/17750) or [Upgrade the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/upgrade-anbox-cloud-appliance/24186) for
+See [How to upgrade Anbox Cloud](https://discourse.ubuntu.com/t/upgrading-from-previous-versions/17750) or [How to upgrade the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/upgrade-anbox-cloud-appliance/24186) for
 instructions on how to update your Anbox Cloud deployment.
 
 [Details=1.13.2]

--- a/tut/creating-addon.md
+++ b/tut/creating-addon.md
@@ -89,4 +89,4 @@ ssh -i ~/ssh-addon-key root@<container_ip> -p <exposed port>
 ## More information about addons
 
 * [Addon reference](https://discourse.ubuntu.com/t/addons/25293)
-* [Updating addons](https://discourse.ubuntu.com/t/update-addons/25286)
+* [How to update addons](https://discourse.ubuntu.com/t/update-addons/25286)

--- a/tut/getting-started-dashboard.md
+++ b/tut/getting-started-dashboard.md
@@ -1,12 +1,12 @@
 This tutorial guides you through the first steps of using Anbox Cloud. You will learn how to create and access a virtual Android device or an application using the [web dashboard](https://discourse.ubuntu.com/t/web-dashboard/20871).
 
-The web dashboard provides an easy-to use interface to Anbox Cloud. However, it currently supports a limited set of functionality, which means that it might not be sufficient for all use cases. If you want to learn how to manage Anbox Cloud from the command line, see the [Getting started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) tutorial.
+The web dashboard provides an easy-to use interface to Anbox Cloud. However, it currently supports a limited set of functionality, which means that it might not be sufficient for all use cases. If you want to learn how to manage Anbox Cloud from the command line, see the [Get started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) tutorial.
 
 [note type="information" status="Important"]
 If you haven't installed Anbox Cloud or the Anbox Cloud Appliance yet, you must do so before you can continue with this tutorial. See the following documentation for installation instructions:
 
-- [Installing the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681)
-- [Install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336) (note that you must install the streaming stack for the web dashboard to be available)
+- [Install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681)
+- [How to install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336) (note that you must install the streaming stack for the web dashboard to be available)
 [/note]
 
 <a name="virtual-device"></a>
@@ -47,7 +47,7 @@ When the application has been initialised and its status changes to `ready`, com
 
 To create an application for a specific Android app, follow the steps in [1. Create a virtual device](#virtual-device), but upload the APK of the Android app.
 
-[note type="information" status="Important"]Not all Android apps are compatible with Anbox Cloud. See [Port Android apps](https://discourse.ubuntu.com/t/port-android-apps/17776) for more information.[/note]
+[note type="information" status="Important"]Not all Android apps are compatible with Anbox Cloud. See [How to port Android apps](https://discourse.ubuntu.com/t/port-android-apps/17776) for more information.[/note]
 
 Choose an [instance type](https://discourse.ubuntu.com/t/instances-types-reference/17764) that is suitable for your application. If your instance is equipped with a GPU and your application requires the use of the GPU for rendering and video encoding, select an instance type with GPU support like `g2.3`. For other instance types, the container will use a GPU if available or software encoding otherwise.
 
@@ -57,7 +57,7 @@ You can launch and test the application in the same way as you did for the virtu
 
 ## 4. Update an application
 
-You can have several versions of an application. See [Update an application](https://discourse.ubuntu.com/t/update-an-application/24201) for detailed information.
+You can have several versions of an application. See [How to update an application](https://discourse.ubuntu.com/t/update-an-application/24201) for detailed information.
 
 Complete the following steps to add a new version to your application:
 
@@ -72,6 +72,6 @@ Complete the following steps to add a new version to your application:
 
 You now know how to use the web dashboard to create, launch and test applications in Anbox Cloud.
 
-If you are interested in more advanced use cases, check out the [Getting started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) tutorial to learn how to use Anbox Cloud from the command line.
+If you are interested in more advanced use cases, check out the [Get started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) tutorial to learn how to use Anbox Cloud from the command line.
 
-Also see the documentation about [how to manage applications](https://discourse.ubuntu.com/t/manage-applications/24333) and [how to work with containers](https://discourse.ubuntu.com/t/work-with-containers/24335).
+Also see the documentation about [How to manage applications](https://discourse.ubuntu.com/t/manage-applications/24333) and [How to work with containers](https://discourse.ubuntu.com/t/work-with-containers/24335).

--- a/tut/getting-started.md
+++ b/tut/getting-started.md
@@ -1,12 +1,12 @@
 This tutorial guides you through the first steps of managing Anbox Cloud from the command line. You will learn how to communicate with [AMS](https://discourse.ubuntu.com/t/about-ams/24321) and how to create and access a virtual Android device or an application.
 
-The tutorial focuses on using the command line to work with Anbox Cloud, which gives you access to all features of Anbox Cloud. Alternatively, you can use the [web dashboard](https://discourse.ubuntu.com/t/web-dashboard/20871), which provides a simpler user interface but does not support all functionality. See the [Getting started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) tutorial for an introduction on how to use the web dashboard.
+The tutorial focuses on using the command line to work with Anbox Cloud, which gives you access to all features of Anbox Cloud. Alternatively, you can use the [web dashboard](https://discourse.ubuntu.com/t/web-dashboard/20871), which provides a simpler user interface but does not support all functionality. See the [Get started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) tutorial for an introduction on how to use the web dashboard.
 
 [note type="information" status="Important"]
 If you haven't installed Anbox Cloud or the Anbox Cloud Appliance yet, you must do so before you can continue with this tutorial. See the following documentation for installation instructions:
 
-- [Installing the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681)
-- [Install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336)
+- [Install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681)
+- [How to install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336)
 [/note]
 
 ## 1. Run AMC
@@ -23,7 +23,7 @@ How and where to run `amc` depends on your use case:
 
         juju ssh ams/0
 
-- If you want to run `amc` on your local Ubuntu-based development machine against a remote Anbox Cloud installation, follow the instructions in [Control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774).
+- If you want to run `amc` on your local Ubuntu-based development machine against a remote Anbox Cloud installation, follow the instructions in [How to control AMS remotely](https://discourse.ubuntu.com/t/managing-ams-access/17774).
 
 To ensure that `amc` is available, run the following command:
 
@@ -125,7 +125,7 @@ When the application for the virtual device is ready, you can launch it and log 
 <a name="scrcpy"></a>
 ## 5. Test the virtual device
 
-You can test the virtual device by connecting to it from your local machine and mirroring its screen. To do so, use the `scrcpy` tool. See [Access a container with scrcpy](https://discourse.ubuntu.com/t/container-access/17772#scrcpy) for more detailed instructions.
+You can test the virtual device by connecting to it from your local machine and mirroring its screen. To do so, use the `scrcpy` tool. See [How to access a container with scrcpy](https://discourse.ubuntu.com/t/container-access/17772#scrcpy) for more detailed instructions.
 
 If you do not have `scrcpy` installed on your local machine, enter the following command to install it:
 
@@ -135,7 +135,7 @@ See the [`scrcpy` documentation](https://github.com/Genymobile/scrcpy) for insta
 
 To connect to your virtual device with `scrcpy`, complete the following steps:
 
-1. Launch a container based on the virtual device application, with the ADB service exposed and graphics enabled: 
+1. Launch a container based on the virtual device application, with the ADB service exposed and graphics enabled:
 
         amc launch virtual-device-cli --service +adb --enable-graphics
 
@@ -170,7 +170,7 @@ To connect to your virtual device with `scrcpy`, complete the following steps:
 
 Creating an application for a specific Android app is very similar to creating a virtual device, except that you provide an APK of the Android app when creating the Anbox Cloud application.
 
-[note type="information" status="Important"]Not all Android apps are compatible with Anbox Cloud. See [Port Android apps](https://discourse.ubuntu.com/t/port-android-apps/17776) for more information.[/note]
+[note type="information" status="Important"]Not all Android apps are compatible with Anbox Cloud. See [How to port Android apps](https://discourse.ubuntu.com/t/port-android-apps/17776) for more information.[/note]
 
 Complete the following steps to create an application from an APK:
 
@@ -200,7 +200,7 @@ When the application is ready, you can launch it and then test it in the same wa
 
 ## 7. Update an application
 
-You can have several versions of an application. See [Update an application](https://discourse.ubuntu.com/t/update-an-application/24201) for detailed information.
+You can have several versions of an application. See [How to update an application](https://discourse.ubuntu.com/t/update-an-application/24201) for detailed information.
 
 Complete the following steps to add a new version to your application:
 
@@ -285,6 +285,6 @@ While following this tutorial, you created several applications and containers. 
 
 You now know how to use the command line to create, launch and test applications in Anbox Cloud.
 
-If you are interested in a more easy-to-use interface, check out the [Getting started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) tutorial to learn how to manage Anbox Cloud using the [web dashboard](https://discourse.ubuntu.com/t/web-dashboard/20871).
+If you are interested in a more easy-to-use interface, check out the [Get started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) tutorial to learn how to manage Anbox Cloud using the [web dashboard](https://discourse.ubuntu.com/t/web-dashboard/20871).
 
-Also see the documentation about [how to manage applications](https://discourse.ubuntu.com/t/manage-applications/24333) and [how to work with containers](https://discourse.ubuntu.com/t/work-with-containers/24335) for more in-depth information.
+Also see the documentation about [How to manage applications](https://discourse.ubuntu.com/t/manage-applications/24333) and [How to work with containers](https://discourse.ubuntu.com/t/work-with-containers/24335) for more in-depth information.

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -1,7 +1,7 @@
 The Anbox Cloud Appliance provides a deployment of Anbox Cloud to a single machine. This offering is well suited for initial prototype and small scale deployments.
 
 [note type="information" status="Note"]
-There are differences between the Anbox Cloud Appliance and the full Anbox Cloud installation (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on the **Anbox Cloud Appliance**. For instructions on how to install **Anbox Cloud**, see [Install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336).
+There are differences between the Anbox Cloud Appliance and the full Anbox Cloud installation (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on the **Anbox Cloud Appliance**. For instructions on how to install **Anbox Cloud**, see [How to install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336).
 [/note]
 
 This tutorial guides you through the steps that are required to install and initialise the Anbox Cloud Appliance, either from the [AWS Marketplace](https://aws.amazon.com/marketplace/) or from the [snap](https://snapcraft.io/anbox-cloud-appliance):
@@ -308,6 +308,6 @@ The output provides a link that you must open in your web browser to finish the 
 
 ## Done!
 
-Your Anbox Cloud Appliance is now fully set up and ready to be used! Next, you should check out the [Getting started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) or the [Getting started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) tutorial to familiarise yourself with how to use Anbox Cloud.
+Your Anbox Cloud Appliance is now fully set up and ready to be used! Next, you should check out the [Get started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/getting-started-with-anbox-cloud-web-dashboard/24958) or the [Get started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/getting-started/17756) tutorial to familiarise yourself with how to use Anbox Cloud.
 
 You can find more information about how to use the appliance in the documentation. The appliance installation is nearly identical to installing via Juju, so all the commands and examples not relating directly to Juju will apply.


### PR DESCRIPTION
Tutorial titles: "Do something" (not "Doing something")
How to titles: "How to do something" (not "Do something")

In the navigation, the "How to" is left out.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>