### PR TITLE
improve formatting of notes

### DIFF
--- a/exp/anbox-cloud.md
+++ b/exp/anbox-cloud.md
@@ -88,6 +88,10 @@ The regular Anbox Cloud variant provides two different Juju bundles:
 
   For more information, see the [charm page](https://charmhub.io/anbox-charmers-anbox-cloud).
 
-[note type="information" status="Tip"]For detailed information about the charm, check the `bundle.yaml` file in the bundle. You can download the bundle with `juju download <charm_name>`, thus `juju download anbox-charmers-anbox-cloud-core` or `juju download anbox-charmers-anbox-cloud`. Unzip the bundle to access the `bundle.yaml` file.[/note]
+[note type="information" status="Tip"]
+For detailed information about the charm, check the `bundle.yaml` file in the bundle.
+
+You can download the bundle with `juju download <charm_name>`, thus `juju download anbox-charmers-anbox-cloud-core` or `juju download anbox-charmers-anbox-cloud`. Unzip the bundle to access the `bundle.yaml` file.
+[/note]
 
 If you don't need to stream the visual output of the Android containers, you can use the `anbox-cloud-core` bundle. Otherwise, you should use the `anbox-cloud` bundle. However, even without the streaming stack, there are still ways to get visual access for inspection purposes. See [How to access a container](https://discourse.ubuntu.com/t/container-access/17772) for details.

--- a/exp/clustering.md
+++ b/exp/clustering.md
@@ -76,13 +76,15 @@ You can change the number of GPU slots of each node with the following command:
 
     amc node set lxd0 gpu-slots 10
 
-> **Note:** Determining the correct number of GPU slots for a specific GPU model depends on various things. The following just gives an idea of what should drive the decision for the right number of GPU slots:
->
-> - Memory a GPU provides
-> - Memory a container uses
-> - Number of parallel encoding pipelines a GPU offers
->
-> Finding the right number of GPU slots requires benchmarking and testing of the intended workload.
+[note type="information" status="Note"]
+Determining the correct number of GPU slots for a specific GPU model depends on various things. The following just gives an idea of what should drive the decision for the right number of GPU slots:
+
+- Memory a GPU provides
+- Memory a container uses
+- Number of parallel encoding pipelines a GPU offers
+
+Finding the right number of GPU slots requires benchmarking and testing of the intended workload.
+[/note]
 
 Launching a container on that node will reserve some of those GPU slots and mark them as unavailable until the container is terminated. If your node has no GPU slot available, containers requiring a GPU will not be launched on it. Containers not requiring a GPU can still be launched.
 

--- a/howto/aar/configure.md
+++ b/howto/aar/configure.md
@@ -116,7 +116,11 @@ To add an AMS client as a trusted [client](https://discourse.ubuntu.com/t/applic
 
     sudo aar trust add client.crt
 
-[note type="information" status="Note"]Due to Snap strict confinement and the AAR sudo requirement, the command requires the certificates to be located in the root user home directory `/root`. To work around this requirement, use the following command: `cat client.crt | sudo aar trust add [--publisher]` [/note]
+[note type="information" status="Note"]
+Due to Snap strict confinement and the AAR sudo requirement, the command requires the certificates to be located in the root user home directory `/root`. To work around this requirement, use the following command:
+
+`cat client.crt | sudo aar trust add [--publisher]`
+[/note]
 
 Finally, reboot the AAR:
 

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -55,7 +55,11 @@ You should see output similar to the following:
 connected to localhost:10000
 ```
 
-[note type="caution" status="Warning"]Appium uses ADB as located in the Android SDK to establish a connection between the remote Android instance and the ADB daemon running on your machine. As mixing different versions of ADB is not supported you need to use ADB from the Android SDK in all cases. If you have the `adb` client installed from other sources, like the Ubuntu package archive, remove it first (`sudo apt purge -y adb`).[/note]
+[note type="caution" status="Warning"]
+Appium uses ADB as located in the Android SDK to establish a connection between the remote Android instance and the ADB daemon running on your machine. As mixing different versions of ADB is not supported you need to use ADB from the Android SDK in all cases. If you have the `adb` client installed from other sources, like the Ubuntu package archive, remove it first:
+
+`sudo apt purge -y adb`
+[/note]
 
 ## Execute Tests with Appium
 

--- a/howto/application/virtual-devices.md
+++ b/howto/application/virtual-devices.md
@@ -11,7 +11,7 @@ name: vdev
 instance-type: a4.3
 ```
 
-[note type="information" status="Note"]If you want to use a GPU for containers created for you new `vdev` application, use an [instance type](https://discourse.ubuntu.com/t/instances-types-reference/17764) with GPU support like `g4.3`.[/note]
+[note type="information" status="Note"]If you want to use a GPU for containers created for your new `vdev` application, use an [instance type](https://discourse.ubuntu.com/t/instances-types-reference/17764) with GPU support like `g4.3`.[/note]
 
 ## Extend the Application with Addons
 

--- a/howto/install/high-availability.md
+++ b/howto/install/high-availability.md
@@ -12,7 +12,13 @@ For example, to go from 1 to 5 ams units, you would run the following:
 
     juju add-unit ams -n 4
 
-[note type="information" status="Hint"]By default Juju allocates small machines to limit costs, but you can request better resources by [enforcing constraints](https://juju.is/docs/olm/constraint): `juju set-constraints anbox-stream-gateway cores=4 memory=8GB`. This is heavily recommended on production environments.[/note]
+[note type="information" status="Hint"]
+By default Juju allocates small machines to limit costs, but you can request better resources by [enforcing constraints](https://juju.is/docs/olm/constraint):
+
+`juju set-constraints anbox-stream-gateway cores=4 memory=8GB`
+
+This is heavily recommended on production environments.
+[/note]
 
 
 ## Anbox Cloud Core

--- a/howto/port/obb-files.md
+++ b/howto/port/obb-files.md
@@ -36,7 +36,11 @@ Let's assume that you have an application that consists of an APK file and an OB
        target: /sdcard/Android/obb/com.foo.bar/
    ```
 
-   [note type="information" status="Note"]The target location of the OBB file varies depending on the app. Some apps load the OBB file from the SD card (`/sdcard/Android/obb/`), while others load it from the device's internal storage (`/data/media/obb`). If an OBB file is not properly installed in the container, the app might not function as expected. Some apps exit immediately if the required OBB file is not found, which triggers the [watchdog](https://discourse.ubuntu.com/t/application-manifest/24197#watchdog) and causes the container to end up in an error state.[/note]
+   [note type="information" status="Note"]
+   The target location of the OBB file varies depending on the app. Some apps load the OBB file from the SD card (`/sdcard/Android/obb/`), while others load it from the device's internal storage (`/data/media/obb`).
+
+   If an OBB file is not properly installed in the container, the app might not function as expected. Some apps exit immediately if the required OBB file is not found, which triggers the [watchdog](https://discourse.ubuntu.com/t/application-manifest/24197#watchdog) and causes the container to end up in an error state.
+   [/note]
 
 1. Create the application:
 


### PR DESCRIPTION
Notes in Discourse CAN actually have internal structure!
If the [/note] is on a separate line instead of at the end
of the last line.

This commit fixes some of the notes that have been simplified
to work without structure.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>