### PR TITLE
Ac 901 jammy images

### DIFF
--- a/howto/manage/images.md
+++ b/howto/manage/images.md
@@ -84,7 +84,7 @@ You must choose a name for the image when uploading it. If you update the image 
 
 Adding an image to AMS can be done with the following command:
 
-    amc image add default anbox-lxd-bionic_1.7_amd64.tar.xz
+    amc image add default anbox-lxd-jammy_x.y_amd64.tar.xz
 
 `default` is the name assigned to the new image. The name can be used by applications to reference the image.
 
@@ -107,7 +107,7 @@ Similar to applications managed by AMS (see [About applications](https://discour
 
 Use the following command to update a manually uploaded image in AMS:
 
-    amc image update default anbox-lxd-bionic_1.7_amd64.tar.xz
+    amc image update default anbox-lxd-jammy_x.y_amd64.tar.xz
 
 `default` is the name assigned to the existing image. Uploading the new image to the connected LXD cluster will take a moment. Once the upload has finished, the image is marked as `active`.
 

--- a/tut/getting-started-dashboard.md
+++ b/tut/getting-started-dashboard.md
@@ -24,7 +24,7 @@ Complete the following steps to create a virtual device:
 2. Click **Add Application**.
 3. Enter a name for the application, for example, `virtual-device-web`.
 4. Keep the preselected instance type.
-5. Select the Android image that you want to use, for example, `bionic:android11:arm64`.
+5. Select the Android image that you want to use, for example, `jammy:android12:arm64`.
 6. Do not upload an APK file.
 7. Click **Add Application**.
 

--- a/tut/getting-started.md
+++ b/tut/getting-started.md
@@ -38,13 +38,21 @@ To check if `amc` is set up to access the correct AMS, run the following command
 Next, check whether AMS has synchronised all images from the Canonical hosted image server. You can list all synchronised images with the `amc image ls` command:
 
 ```bash
-+----------------------+-----------------------------+--------+----------+--------------+---------+
-| ID                   | NAME                        | STATUS | VERSIONS | ARCHITECTURE | DEFAULT |
-+----------------------+-----------------------------+--------+----------+--------------+---------+
-| c4b4djkrorjohh948dfg | bionic:android11:arm64      | active | 1        | aarch64      | true    |
-+----------------------+-----------------------------+--------+----------+--------------+---------+
-| c4b4ev4rorjohh948dg0 | bionic:android10:arm64      | active | 1        | aarch64      | false   |
-+----------------------+-----------------------------+--------+----------+--------------+---------+
++----------------------+------------------------+--------+----------+--------------+---------+
+|          ID          |          NAME          | STATUS | VERSIONS | ARCHITECTURE | DEFAULT |
++----------------------+------------------------+--------+----------+--------------+---------+
+| caa6s5l07mps24asmii0 | jammy:android12:arm64  | active | 1        | aarch64      | true    |
++----------------------+------------------------+--------+----------+--------------+---------+
+| caa6scl07mps24asmiig | jammy:android11:arm64  | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| caa6sil07mps24asmij0 | jammy:android10:arm64  | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| caa6sol07mps24asmijg | bionic:android12:arm64 | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| caa6t2d07mps24asmik0 | bionic:android11:arm64 | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| caa6ta507mps24asmikg | bionic:android10:arm64 | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
 ```
 
 See [Provided images](https://discourse.ubuntu.com/t/provided-images/24185) for more information.


### PR DESCRIPTION
- Update references to bionic and focal images with references to jammy images
- Update the requirements to support jammy for the full deployment (not the appliance)