### PR TITLE
update documentation about images

### DIFF
--- a/howto/manage/images.md
+++ b/howto/manage/images.md
@@ -4,45 +4,51 @@ See [Provided images](https://discourse.ubuntu.com/t/provided-images/24185) for 
 
 ## Configure image server
 
-Using the image server hosted by Canonical enables automated updates on your Anbox Cloud deployment. AMS will automatically synchronise new image versions in regular intervals and update your applications. Using the image server should be preferred over using manually managed images. Images on the image server are updated for important security updates or bug fixes, and with every release of Anbox Cloud.
+The Canonical image server provides different Anbox Cloud images that are updated regularly. AMS automatically synchronises new image versions in regular intervals and updates your applications to use these new versions. The images on the image server are updated for important security updates or bug fixes, and with every release of Anbox Cloud.
 
-Starting with Anbox Cloud 1.9, access to the image server is automatically configured as part of your Ubuntu Advantage subscription during the charm deployment. No further manual steps are necessary.
+Access to the image server is automatically configured as part of your Ubuntu Advantage subscription during the charm deployment. No further manual steps are necessary.
 
-AMS will start automatically to import images available on the image server. The `images.update_interval` configuration option allows to customise how often AMS looks for new images. You can set it to a desired interval with the following command:
+AMS will automatically start importing the images available on the image server. The `images.update_interval` configuration option allows to customise how often AMS looks for new images. You can set it to a desired interval with the following command:
 
     amc config set images.update_interval 5m
 
-Synchronised images will become available next to images you manually add:
+You can see the synchronised images with the `amc image list` command:
 
 ```bash
-+----------------------+-----------------------------+--------+----------+
-|          ID          |            NAME             | STATUS | VERSIONS |
-+----------------------+-----------------------------+--------+----------+
-| bj03g89hpuo10ed1riog | io.anbox-cloud:nougat:amd64 | active | 1        |
-+----------------------+-----------------------------+--------+----------+
-| bj003kphpuo2bt5edjtg | default                     | active | 1        |
-+----------------------+-----------------------------+--------+----------+
++----------------------+------------------------+--------+----------+--------------+---------+
+|          ID          |          NAME          | STATUS | VERSIONS | ARCHITECTURE | DEFAULT |
++----------------------+------------------------+--------+----------+--------------+---------+
+| cbv37rfu3kvchoeai3kg | jammy:android12:arm64  | active | 1        | aarch64      | true    |
++----------------------+------------------------+--------+----------+--------------+---------+
+| cbv384vu3kvchoeai3l0 | jammy:android11:arm64  | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| cbv38gnu3kvchoeai3lg | jammy:android10:arm64  | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| cbv393nu3kvchoeai3m0 | bionic:android12:arm64 | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| cbv39mvu3kvchoeai3mg | bionic:android11:arm64 | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
+| cbv3a4vu3kvchoeai3n0 | bionic:android10:arm64 | active | 1        | aarch64      | false   |
++----------------------+------------------------+--------+----------+--------------+---------+
 ```
 
 ## Default image
-When adding your first image to AMS, it is marked as the default image.
+The first image that is synchronised (usually the newest image) is marked as the default image.
 The default image is used when you create an application without the `image` field or launch a raw container without specifying any ID.
 
 You can set any image as your default with the following command:
 
-    amc image switch bcpm2r2hmss0427lkrn0
+    amc image switch bionic:android12:arm64
 
 Running `amc image list` will now show this image marked as default.
-
-[note type="information" status="Hint"]Note that you cannot delete an image marked as default. You'll need to set a new default image first. *(does not apply if you only have one image left)*[/note]
 
 ## Delete an image
 
 Deleting an image will make it unavailable to Anbox Cloud. However, it will not affect any application based on the image directly, as the application keeps a copy of the image internally. As the image is not available to AMS anymore after deleting it, updating the underlying image of applications with a new version is not possible anymore.
 
-Deleting a specific image can be achieved with the following command, where `default` is the name of the image to delete:
+Deleting a specific image can be achieved with the following command, where `image-name` is the name of the image to delete:
 
-    amc image delete default
+    amc image delete image-name
 
 Images that are synchronised from the image server are marked as immutable. To delete such images, add the `--force` flag:
 
@@ -50,13 +56,15 @@ Images that are synchronised from the image server are marked as immutable. To d
 
 If you're not using `--force`, the command will fail.
 
+[note type="information" status="Hint"]Note that unless you have only one image left, you cannot delete an image that is marked as default. You must set a new default image first.[/note]
+
 ### Delete an image version
 
 Specific image versions can be deleted too, which is useful when all applications were migrated to a newer version and the old version is not needed anymore. The only requirement is that a single version of the image is available at all times.
 
-The following command removes version `1` of the image with the name `default`:
+The following command removes version `1` of the image with the name `image-name`:
 
-    amc image delete default --version=1
+    amc image delete image-name --version=1
 
 ## Use a specific release of an image
 
@@ -73,46 +81,3 @@ You can then use the `foobar` image as you would any other image.
 [note type="information" status="Tip"]
 Image updates contain important security patches and optimisations. Use older images only when strictly necessary.
 [/note]
-
-## Manual upload of images
-
-In addition to the images provided through Canonical's image server, you can manually upload your own images to be used by AMS.
-
-You must choose a name for the image when uploading it. If you update the image later, use the same name so that the image is not re-created but simply updated.
-
-### Add an image to AMS
-
-Adding an image to AMS can be done with the following command:
-
-    amc image add default anbox-lxd-jammy_x.y_amd64.tar.xz
-
-`default` is the name assigned to the new image. The name can be used by applications to reference the image.
-
-Each image gets a unique ID assigned which can be used to retrieve further information about the image with `amc image show <ID>`:
-
-```bash
-id: bcpm2r2hmss0427lkrn0
-name: default
-status: active
-versions:
-    0:
-        size: 374.69MB
-        created-at: 2018-06-27 10:05:32 +0000 UTC
-        status: active
-```
-
-Similar to applications managed by AMS (see [About applications](https://discourse.ubuntu.com/t/managing-applications/17760)), images have a list of versions too. A new version is created each time an image is updated.
-
-### Update an existing image
-
-Use the following command to update a manually uploaded image in AMS:
-
-    amc image update default anbox-lxd-jammy_x.y_amd64.tar.xz
-
-`default` is the name assigned to the existing image. Uploading the new image to the connected LXD cluster will take a moment. Once the upload has finished, the image is marked as `active`.
-
-Now that a new image version is available to AMS, it will start to create new versions of all available applications but won't publish them. Creating new versions of each application can take a moment depending on the current load of the cluster. You can see available versions of a specific application with the following command:
-
-    amc application show <id>
-
-Each version will give information about which version of an image it is based on.

--- a/ref/provided-images.md
+++ b/ref/provided-images.md
@@ -1,12 +1,12 @@
 Anbox Cloud provides images based on different Android versions and different architectures (amd64, arm64). AMS manages these images, which can be individually selected by applications. When an image is updated, all applications using the image are automatically updated and rebased on the new image version.
 
-Officially released images are available from the [official image server](https://images.anbox-cloud.io) hosted by Canonical.
+Officially released images are available from the [official image server](https://images.anbox-cloud.io) hosted by Canonical. It is currently not possible to build custom images for Anbox Cloud.
 
 [note type="information" status="Note"]Anbox images are regular [Ubuntu cloud images](https://cloud-images.ubuntu.com/) where Anbox and its dependencies are installed. Unnecessary packages are removed to improve images size, boot time and security.[/note]
 
 ## Official images
 
-The official image server has a set of images available. The following table lists all images and their corresponding Android and Ubuntu versions. Please note the support status for each of the images.
+The following table lists all images that are available on the official image server, along with their corresponding Android and Ubuntu versions. Please note the support status for each of the images.
 
 | Name                        | Android Version | Ubuntu Version | Support Status     | Available since |
 |-----------------------------|-----------------|----------------|------------|---------------|


### PR DESCRIPTION
In particular, remove information that makes it seem like users
can add custom images.
This is generally possible, but only if we provide them with an
image, and then we'll also provide them with instructions.

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>