### PR TITLE
Add how-to bug-report

### DIFF
--- a/howto/troubleshoot/collect-info.md
+++ b/howto/troubleshoot/collect-info.md
@@ -1,0 +1,23 @@
+The guides in this section describe how to collect troubleshooting information
+from various parts of the Anbox Cloud stack. These guides should be used to
+analyse or report issues with Anbox Cloud.
+
+Before you follow the steps outlined in this section, check the instructions for
+commonly encountered problems at [How to troubleshoot Anbox
+Cloud](https://discourse.ubuntu.com/t/how-to-troubleshoot-anbox-cloud/17837).
+
+## How to collect troubleshooting information from a container
+
+*Applies to: Anbox Cloud, Anbox Cloud Appliance since 1.16.0*
+
+Anbox containers come preinstalled with the `anbox-bug-report` utility, which
+collects the log files and other relevant information for a specific container.
+To generate the report and save it to a local file, use `amc exec` on a running
+container:
+
+```
+amc exec <container_id> -- bash -c 'cat "$(anbox-bug-report)"' > "<target_file>"
+```
+
+This command builds a zip archive that contains the container report. It then
+saves it to the local `<target_file>`. This process might take a few seconds.

--- a/index.md
+++ b/index.md
@@ -123,6 +123,7 @@ Thinking about using Anbox Cloud for your next project? [Get in touch!](https://
 | 3 | howto/cluster/scale-up | [Scale up a LXD cluster](https://discourse.ubuntu.com/t/scale-up-a-lxd-cluster/24322)|
 | 3 | howto/cluster/scale-down | [Scale down a LXD cluster](https://discourse.ubuntu.com/t/scale-down-a-lxd-cluster/24323)|
 | 2 | howto/troubleshoot/landing | [Troubleshoot Anbox Cloud](https://discourse.ubuntu.com/t/anbox-cloud-faq/17837)|
+| 3 | howto/troubleshoot/collect-info | [Collect information](tbd)|
 | 0 | | |
 | 1 | ref/landing | [Reference](https://discourse.ubuntu.com/t/reference/28828) |
 | 2 | ref/provided-images | [Provided images](https://discourse.ubuntu.com/t/provided-images/24185)|


### PR DESCRIPTION
This describes how to use the `anbox-bug-report` script which should be available from Anbox Cloud 1.16 onwards.

With contributions from @ru-fu and @adglkh