### PR TITLE
Clarify Ubuntu Pro subscription requirement for Anbox Cloud

### DIFF
--- a/exp/anbox-cloud.md
+++ b/exp/anbox-cloud.md
@@ -29,7 +29,7 @@ See the following table for a comparison of features for the different variants:
 | [Vendor support available](https://ubuntu.com/support) | ✓* | ✓ |
 | [Monitoring](https://discourse.ubuntu.com/t/monitor-anbox-cloud/24338) | - | ✓ |
 
-*\* When purchasing the Anbox Cloud Appliance through the AWS Marketplace, the standard Ubuntu Pro subscription does not include vendor support.*
+*\* When purchasing the Anbox Cloud Appliance through the AWS Marketplace, the Ubuntu Pro subscription does not include vendor support.*
 
 Which of both variants you choose depends on your needs. The appliance is well suited for quick prototyping and development or small scale deployments, whereas the regular Anbox Cloud is best to scale big.
 

--- a/howto/install-appliance/azure.md
+++ b/howto/install-appliance/azure.md
@@ -11,8 +11,8 @@ Check the hardware requirements for the Anbox Cloud Appliance [here](https://dis
 In addition, make sure you have the following prerequisites:
 
 * An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
-* Your Ubuntu Pro token for either a full Ubuntu Pro subscription or a Ubuntu Pro (Apps-only) subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, sign in on https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token that every user gets for free does **NOT** work and will result in a failed deployment. You must purchase a full *Ubuntu Pro* or a *Ubuntu Pro (Apps-only)* subscription by [contacting Canonical](https://anbox-cloud.io/contact-us).[/note]
+* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
 * An Azure account that you use to create the virtual machine.
 
 ## Create a virtual machine

--- a/howto/install-appliance/azure.md
+++ b/howto/install-appliance/azure.md
@@ -12,7 +12,7 @@ In addition, make sure you have the following prerequisites:
 
 * An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
 * Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an *Ubuntu Pro* subscription.[/note]
 * An Azure account that you use to create the virtual machine.
 
 ## Create a virtual machine

--- a/howto/install-appliance/azure.md
+++ b/howto/install-appliance/azure.md
@@ -11,7 +11,7 @@ Check the hardware requirements for the Anbox Cloud Appliance [here](https://dis
 In addition, make sure you have the following prerequisites:
 
 * An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
-* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
   [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
 * An Azure account that you use to create the virtual machine.
 

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -7,8 +7,8 @@ Alternatively, you can follow the instructions in this document to use the [manu
 Before you start the installation, ensure that you have the required prerequisites:
 
 * At least three Ubuntu machines. See [Minimum hardware](https://discourse.ubuntu.com/t/requirements/17734#minimum-hardware) for details and recommendations.
-* Your Ubuntu Pro token for either a full Ubuntu Pro subscription or a Ubuntu Pro (Apps-only) subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, sign in on https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token that every user gets for free does **NOT** work and will result in a failed deployment. You must purchase a full *Ubuntu Pro* or a *Ubuntu Pro (Apps-only)* subscription by [contacting Canonical](https://anbox-cloud.io/contact-us).[/note]
+* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
 
 ## Install Juju
 

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -7,7 +7,7 @@ Alternatively, you can follow the instructions in this document to use the [manu
 Before you start the installation, ensure that you have the required prerequisites:
 
 * At least three Ubuntu machines. See [Minimum hardware](https://discourse.ubuntu.com/t/requirements/17734#minimum-hardware) for details and recommendations.
-* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
   [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
 
 ## Install Juju

--- a/howto/install/deploy-bare-metal.md
+++ b/howto/install/deploy-bare-metal.md
@@ -8,7 +8,7 @@ Before you start the installation, ensure that you have the required prerequisit
 
 * At least three Ubuntu machines. See [Minimum hardware](https://discourse.ubuntu.com/t/requirements/17734#minimum-hardware) for details and recommendations.
 * Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an *Ubuntu Pro* subscription.[/note]
 
 ## Install Juju
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -15,8 +15,8 @@ Before you start the installation, ensure that you have the required credentials
   * [Amazon Web Services](https://aws.amazon.com/) (including AWS-China)
   * [Google Cloud platform ](https://cloud.google.com/)
   * [Microsoft Azure](https://azure.microsoft.com/)
-* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full Ubuntu Pro subscription.[/note]
+* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an Ubuntu Pro subscription.[/note]
 
 ## Install Juju
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -61,7 +61,7 @@ Every deployment of Anbox Cloud must be attached to the Ubuntu Pro service Canon
 
 You can retrieve your Ubuntu Pro token at https://ubuntu.com/pro after logging in. You should record the token as you will need it for every deployment of Anbox Cloud.
 
-[note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
+[note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token will result in a failed deployment. You need an *Ubuntu Pro* subscription.[/note]
 
 To provide your token when deploying with Juju, you need an [overlay file](https://discourse.ubuntu.com/t/installation-customizing/17747#overlay-files) named `ua.yaml`. For the `anbox-cloud` bundle, the `ua.yaml` file should look like this:
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -15,8 +15,8 @@ Before you start the installation, ensure that you have the required credentials
   * [Amazon Web Services](https://aws.amazon.com/) (including AWS-China)
   * [Google Cloud platform ](https://cloud.google.com/)
   * [Microsoft Azure](https://azure.microsoft.com/)
-* Your Ubuntu Pro token for either a full Ubuntu Pro subscription or a Ubuntu Pro (Apps-only) subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, sign in on https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token that every user gets for free does **NOT** work and will result in a failed deployment. You must purchase a full *Ubuntu Pro* or a *Ubuntu Pro (Apps-only)* subscription by [contacting Canonical](https://anbox-cloud.io/contact-us).[/note]
+* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full Ubuntu Pro subscription.[/note]
 
 ## Install Juju
 
@@ -61,7 +61,7 @@ Every deployment of Anbox Cloud must be attached to the Ubuntu Pro service Canon
 
 You can retrieve your Ubuntu Pro token at https://ubuntu.com/pro after logging in. You should record the token as you will need it for every deployment of Anbox Cloud.
 
-[note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token that every user gets for free does **NOT** work and will result in a failed deployment. You must purchase a full *Ubuntu Pro* or a *Ubuntu Pro (Apps-only)* subscription by [contacting Canonical](https://anbox-cloud.io/contact-us).[/note]
+[note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
 
 To provide your token when deploying with Juju, you need an [overlay file](https://discourse.ubuntu.com/t/installation-customizing/17747#overlay-files) named `ua.yaml`. For the `anbox-cloud` bundle, the `ua.yaml` file should look like this:
 

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -10,9 +10,9 @@ You might encounter the following issues while setting up your system.
 
 > Several Juju units of my deployment show `hook: installation failure`. Why?
 
-You used the wrong Ubuntu Pro token. Most likely, you used the Ubuntu Pro (Infra-only) token that every user gets for free limited personal use.
+You used the wrong Ubuntu Pro token. Using the Ubuntu Pro (Infra-only) token will result in a failed deployment.
 
-To deploy Anbox Cloud, you need a commercial subscription for Ubuntu Pro (full or Apps-only). Using a different token will result in a failed deployment. This failure is currently not recoverable.
+To deploy Anbox Cloud, you need a commercial subscription for full Ubuntu Pro. Using a different token will result in a failed deployment. This failure is currently not recoverable.
 
 ### Socket permission error for `amc`
 

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -12,7 +12,7 @@ You might encounter the following issues while setting up your system.
 
 You used the wrong Ubuntu Pro token. Using the Ubuntu Pro (Infra-only) token will result in a failed deployment.
 
-To deploy Anbox Cloud, you need a commercial subscription for full Ubuntu Pro. Using a different token will result in a failed deployment. This failure is currently not recoverable.
+To deploy Anbox Cloud, you need an Ubuntu Pro subscription. Using a different token will result in a failed deployment. This failure is currently not recoverable.
 
 ### Socket permission error for `amc`
 

--- a/howto/update/upgrade-anbox.md
+++ b/howto/update/upgrade-anbox.md
@@ -57,7 +57,7 @@ Once the commands are executed, Juju will perform all necessary upgrade steps au
 
 After Juju has settled the workload status will be marked as `blocked` and the status will show `UA token missing`.
 
-Anbox Cloud requires a valid Ubuntu Pro token including the Anbox Cloud entitlement, thus a full Ubuntu Pro or a Ubuntu Pro (Apps-only) subscription. You can get your Ubuntu Pro token on [Ubuntu Pro](https://ubuntu.com/pro). Please speak with your Canonical account representative.
+Anbox Cloud requires a valid Ubuntu Pro token for a full Ubuntu Pro subscription which includes the Anbox Cloud entitlement. You can get your Ubuntu Pro token on [Ubuntu Pro](https://ubuntu.com/pro). Please speak with your Canonical account representative.
 
 When you have your Ubuntu Pro token, you can apply it for all relevant charms with the following commands:
 

--- a/howto/update/upgrade-anbox.md
+++ b/howto/update/upgrade-anbox.md
@@ -57,7 +57,7 @@ Once the commands are executed, Juju will perform all necessary upgrade steps au
 
 After Juju has settled the workload status will be marked as `blocked` and the status will show `UA token missing`.
 
-Anbox Cloud requires a valid Ubuntu Pro token for a full Ubuntu Pro subscription which includes the Anbox Cloud entitlement. You can get your Ubuntu Pro token on [Ubuntu Pro](https://ubuntu.com/pro). Please speak with your Canonical account representative.
+Anbox Cloud requires a valid Ubuntu Pro token for an Ubuntu Pro subscription which includes the Anbox Cloud entitlement. You can get your Ubuntu Pro token on [Ubuntu Pro](https://ubuntu.com/pro). Please speak with your Canonical account representative.
 
 When you have your Ubuntu Pro token, you can apply it for all relevant charms with the following commands:
 

--- a/ref/glossary.md
+++ b/ref/glossary.md
@@ -435,14 +435,14 @@ A server that finds the most optimal network path between a client and the conta
 <a name="ubuntu-pro"></a>
 ### Ubuntu Pro
 
-Canonical’s service package for Ubuntu that provides enterprise security and support for open-source applications, with managed service offerings available. Note the difference between Ubuntu Pro (Infra-only) and full Ubuntu Pro subscriptions. Anbox Cloud requires a full Ubuntu Pro subscription.
+Canonical’s service package for Ubuntu that provides enterprise security and support for open-source applications, with managed service offerings available. Note the difference between Ubuntu Pro (Infra-only) and Ubuntu Pro subscriptions. Anbox Cloud requires an Ubuntu Pro subscription.
 
 See [Ubuntu Pro](https://ubuntu.com/support).
 
 <a name="ubuntu-one"></a>
 ### Ubuntu One
 
-A central user account system used by all Canonical sites and services. You need a Ubuntu One account to purchase the full Ubuntu Pro subscription that is required to run Anbox Cloud, and to log in to the web dashboard.
+A central user account system used by all Canonical sites and services. You need an Ubuntu One account to purchase the Ubuntu Pro subscription that is required to run Anbox Cloud, and to log in to the web dashboard.
 
 See [Ubuntu One](https://login.ubuntu.com/).
 

--- a/ref/glossary.md
+++ b/ref/glossary.md
@@ -442,7 +442,7 @@ See [Ubuntu Pro](https://ubuntu.com/support).
 <a name="ubuntu-one"></a>
 ### Ubuntu One
 
-A central user account system used by all Canonical sites and services. You need a Ubuntu One account to purchase the Ubuntu Pro (Apps-only) subscription that is required to run Anbox Cloud, and to log into the web dashboard.
+A central user account system used by all Canonical sites and services. You need a Ubuntu One account to purchase the full Ubuntu Pro subscription that is required to run Anbox Cloud, and to log in to the web dashboard.
 
 See [Ubuntu One](https://login.ubuntu.com/).
 

--- a/ref/glossary.md
+++ b/ref/glossary.md
@@ -435,7 +435,7 @@ A server that finds the most optimal network path between a client and the conta
 <a name="ubuntu-pro"></a>
 ### Ubuntu Pro
 
-Canonical’s service package for Ubuntu that provides enterprise security and support for open-source applications, with managed service offerings available. Note the difference between Ubuntu Pro (Infra-only) and Ubuntu Pro (Apps-only); Anbox Cloud requires a full Ubuntu Pro or a Ubuntu Pro (Apps-only) subscription.
+Canonical’s service package for Ubuntu that provides enterprise security and support for open-source applications, with managed service offerings available. Note the difference between Ubuntu Pro (Infra-only) and full Ubuntu Pro subscriptions. Anbox Cloud requires a full Ubuntu Pro subscription.
 
 See [Ubuntu Pro](https://ubuntu.com/support).
 

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -20,8 +20,8 @@ Make sure you have the following prerequisites:
 
 * An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
 * A virtual or bare metal machine running Ubuntu 20.04 or 22.04. See the detailed requirements [here](https://discourse.ubuntu.com/t/requirements/17734).
-* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
+* Your Ubuntu Pro token for an Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need an *Ubuntu Pro* subscription.[/note]
 
 <a name="install"></a>
 ## Install the appliance
@@ -51,7 +51,7 @@ If LXD is already installed but the version is older than 5.0, run:
 
 ### 3. Attach your machine to the Ubuntu Pro subscription
 
-The Anbox Cloud Appliance requires a valid full Ubuntu Pro subscription.
+The Anbox Cloud Appliance requires a valid Ubuntu Pro subscription.
 
 Before installing the appliance, you must attach the machine on which you want to run the Anbox Cloud Appliance to your Ubuntu Pro subscription. To do so, run the following command, replacing *<UA_token>* with your Ubuntu Pro token:
 

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -20,8 +20,8 @@ Make sure you have the following prerequisites:
 
 * An Ubuntu SSO account. If you don't have one yet, create it [here](https://login.ubuntu.com).
 * A virtual or bare metal machine running Ubuntu 20.04 or 22.04. See the detailed requirements [here](https://discourse.ubuntu.com/t/requirements/17734).
-* Your Ubuntu Pro token for either a full Ubuntu Pro subscription or a Ubuntu Pro (Apps-only) subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, sign in on https://ubuntu.com/pro to retrieve it.
-  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token that every user gets for free does **NOT** work and will result in a failed deployment. You must purchase a full *Ubuntu Pro* or a *Ubuntu Pro (Apps-only)* subscription by [contacting Canonical](https://anbox-cloud.io/contact-us).[/note]
+* Your Ubuntu Pro token for a full Ubuntu Pro subscription. If you don't have one yet, [speak to your Canonical representative](https://anbox-cloud.io/contact-us). If you already have a valid Ubuntu Pro token, log in to https://ubuntu.com/pro to retrieve it.
+  [note type="caution" status="Warning"]The *Ubuntu Pro (Infra-only)* token does **NOT** work and will result in a failed deployment. You need a full *Ubuntu Pro* subscription.[/note]
 
 <a name="install"></a>
 ## Install the appliance
@@ -51,7 +51,7 @@ If LXD is already installed but the version is older than 5.0, run:
 
 ### 3. Attach your machine to the Ubuntu Pro subscription
 
-The Anbox Cloud Appliance requires a valid Ubuntu Pro subscription (either a full Ubuntu Pro subscription or a Ubuntu Pro (Apps-only) subscription).
+The Anbox Cloud Appliance requires a valid full Ubuntu Pro subscription.
 
 Before installing the appliance, you must attach the machine on which you want to run the Anbox Cloud Appliance to your Ubuntu Pro subscription. To do so, run the following command, replacing *<UA_token>* with your Ubuntu Pro token:
 


### PR DESCRIPTION
Modify warning messages to reflect the full Ubuntu Pro requirement for Anbox Cloud based on the current offerings.

Signed-off-by: Keirthana T S <keirthana.ts@canonical.com>