### PR TITLE
Change 'a Ubuntu' to 'an Ubuntu'

### DIFF
--- a/howto/anbox/develop-platform.md
+++ b/howto/anbox/develop-platform.md
@@ -1,6 +1,6 @@
 Anbox Cloud provides a platform SDK that allows the development of custom platform plugins for the Anbox runtime, for use cases where the [default platforms](https://anbox-cloud.io/docs/ref/platforms) don't fit. For example, a custom platform can be used to integrate a custom streaming protocol with the Anbox runtime.
 
-This guide assumes that all steps are run on a Ubuntu 22.04 machine that hosts the [Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).
+This guide assumes that all steps are run on an Ubuntu 22.04 machine that hosts the [Anbox Cloud Appliance](https://discourse.ubuntu.com/t/install-appliance/22681).
 
 ## Preparation
 

--- a/howto/manage/manage-appliance.md
+++ b/howto/manage/manage-appliance.md
@@ -15,7 +15,7 @@ The available commands for the `anbox-cloud-appliance` tool are:
   Generate a tarball that contains debug information.
 - `dashboard`
 
-  Manage the web dashboard and access to it. By default, the dashboard is enabled and exposed, but you can disable it. You can also register new users for the web dashboard. See [Register a Ubuntu One account in Anbox Cloud Appliance](https://discourse.ubuntu.com/t/web-dashboard/20871#dashboard-access-appliance) for more information.
+  Manage the web dashboard and access to it. By default, the dashboard is enabled and exposed, but you can disable it. You can also register new users for the web dashboard. See [Register an Ubuntu One account in Anbox Cloud Appliance](https://discourse.ubuntu.com/t/web-dashboard/20871#dashboard-access-appliance) for more information.
 - `destroy`
 
   If you want to uninstall the Anbox Cloud Appliance, you must first destroy the deployment. Run this command before you uninstall the snap.

--- a/howto/manage/web-dashboard.md
+++ b/howto/manage/web-dashboard.md
@@ -23,9 +23,9 @@ If you haven't registered an Ubuntu One account yet, you can do that at https://
 
 Before you can log into the dashboard, you must register your Ubuntu One account with the dashboard to grant it access.
 
-#### Register a Ubuntu One account in Anbox Cloud
+#### Register an Ubuntu One account in Anbox Cloud
 
-On a regular Anbox Cloud deployment, use the following Juju action to register a Ubuntu One account:
+On a regular Anbox Cloud deployment, use the following Juju action to register an Ubuntu One account:
 
     juju run-action anbox-cloud-dashboard/0 --wait register-account email=<Ubuntu One email address>
 
@@ -46,7 +46,7 @@ unit-anbox-cloud-dashboard-0:
 ```
 
 <a name="dashboard-access-appliance"></a>
-#### Register a Ubuntu One account in Anbox Cloud Appliance
+#### Register an Ubuntu One account in Anbox Cloud Appliance
 
 If you followed the instructions in the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial or in [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702), you already registered your Ubuntu One account.
 

--- a/requirements.md
+++ b/requirements.md
@@ -17,7 +17,7 @@ After registering to Anbox Cloud, you should have received a [Ubuntu Pro](https:
 
 Anbox Cloud is supported only on the [Ubuntu](https://ubuntu.com/) operating system. Other Linux-based operating systems are not supported.
 
-You must run either the [server](https://ubuntu.com/download/server) or the [cloud](https://ubuntu.com/download/cloud) variant of Ubuntu. Running Anbox Cloud on a Ubuntu Desktop installation is not supported.
+You must run either the [server](https://ubuntu.com/download/server) or the [cloud](https://ubuntu.com/download/cloud) variant of Ubuntu. Running Anbox Cloud on an Ubuntu Desktop installation is not supported.
 
 See [Ubuntu version for the Anbox Cloud Appliance](#appliance-ubuntu-version) or [Ubuntu version for Juju-based deployments](#ac-ubuntu-version) for information about the supported Ubuntu versions.
 


### PR DESCRIPTION
Changed all occurences of 'a Ubuntu' to 'an Ubuntu' in our docs