### PR TITLE
Add note to discourage using LXD commands

### DIFF
--- a/howto/container/start.md
+++ b/howto/container/start.md
@@ -4,6 +4,10 @@ When a container is either initialised with the `amc init` (see [Create a contai
 
 `<container id>` is the ID of the container that you want to start.
 
+[note type="information" status="Important"]
+Do not use the `lxd` command to start a container. Always use the `amc` command instead. Anbox Cloud containers have their own lifecycle and using the `lxd` command to start a container can cause the container to be out of sync.
+[/note]
+
 By default, the `amc start` command waits 5 minutes for a container to run before the operation times out. When starting a container, you can specify a custom wait time with the `--timeout` option.
 
     amc start <container id> --timeout 10m

--- a/howto/container/start.md
+++ b/howto/container/start.md
@@ -5,7 +5,7 @@ When a container is either initialised with the `amc init` (see [Create a contai
 `<container id>` is the ID of the container that you want to start.
 
 [note type="information" status="Important"]
-Do not use the `lxd` command to start a container. Always use the `amc` command instead. Anbox Cloud containers have their own lifecycle and using the `lxd` command to start a container can cause the container to be out of sync.
+Do not use the `lxc` command to manage a container. Always use the `amc` command instead. Anbox Cloud containers have their own lifecycle and using the `lxc` command to manage a container can cause the container to be out of sync.
 [/note]
 
 By default, the `amc start` command waits 5 minutes for a container to run before the operation times out. When starting a container, you can specify a custom wait time with the `--timeout` option.

--- a/howto/container/stop.md
+++ b/howto/container/stop.md
@@ -4,6 +4,10 @@ A running container can be stopped using the `amc stop` command:
 
 `<container id>` is the ID of the container that you want to stop.
 
+[note type="information" status="Important"]
+Do not use the `lxd` command to stop a container. Always use the `amc` command instead. Anbox Cloud containers have their own lifecycle and using the `lxd` command to stop a container can cause the container to be out of sync.
+[/note]
+
 By default, the `amc stop` command waits 5 minutes for a container to stop before the operation times out. If you want to specify a custom wait time, you can do so by using the `--timeout` option in the `amc stop` command.
 
     amc stop <container id> --timeout 10m

--- a/howto/container/stop.md
+++ b/howto/container/stop.md
@@ -5,7 +5,7 @@ A running container can be stopped using the `amc stop` command:
 `<container id>` is the ID of the container that you want to stop.
 
 [note type="information" status="Important"]
-Do not use the `lxd` command to stop a container. Always use the `amc` command instead. Anbox Cloud containers have their own lifecycle and using the `lxd` command to stop a container can cause the container to be out of sync.
+Do not use the `lxc` command to manage a container. Always use the `amc` command instead. Anbox Cloud containers have their own lifecycle and using the `lxc` command to manage a container can cause the container to be out of sync.
 [/note]
 
 By default, the `amc stop` command waits 5 minutes for a container to stop before the operation times out. If you want to specify a custom wait time, you can do so by using the `--timeout` option in the `amc stop` command.


### PR DESCRIPTION
Add a note to discourage the use of `lxd` commands to start and stop a container and recommend use of `amc` commands only.