### PR TITLE
Check notes formatting

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -186,6 +186,7 @@ RGBA
 roadmap
 RootFS
 RSA
+rsa
 RTC
 RTP
 RTT

--- a/exp/application-streaming.md
+++ b/exp/application-streaming.md
@@ -42,7 +42,7 @@ The following provides an overview of the process:
  5. Each network path is bundled in an `ICE candidate`. There are usually multiple ICE candidates per peer and both sides negotiate the best candidate pair.
  6. Both peer agree on the best network path (`ICE candidate`) and start the actual streaming. At this point, they stop communicating through the Gateway web socket and talk directly to each other.
 
-[note type="information" status="Hint"]The server itself does not need to know about the messages content, it just has to forward messages from one peer to the other.[/note]
+[note type="information" status="Note"]The server itself does not need to know about the messages content, it just has to forward messages from one peer to the other.[/note]
 
 ### 3. Establishing the stream
 

--- a/howto/aar/configure.md
+++ b/howto/aar/configure.md
@@ -14,7 +14,7 @@ To register an instance as a publisher, use the following command:
 
     juju add-relation aar:publisher ams:registry-publisher
 
-[note type="information" status="Hint"]Run `amc config show` to check that the AAR configuration items were changed.[/note]
+[note type="information" status="Tip"]Run `amc config show` to check that the AAR configuration items were changed.[/note]
 
 ### Register units deployed in another model
 

--- a/howto/application/extend.md
+++ b/howto/application/extend.md
@@ -1,7 +1,7 @@
 You can extend an application either by adding [hooks](#application-hooks) directly to the application or by creating an [addon](#addon) that includes one or more hooks and adding it to the application.
 
-- If you want to extend one application only, you should use application hooks. They are easy and quick to set up and do not require creating an addon.
-- If your extension contains common functionality that you want to share among multiple applications, you should create an addon that includes one or more hooks. You can then add the addon to all applications that should use the functionality.
+* If you want to extend one application only, you should use application hooks. They are easy and quick to set up and do not require creating an addon.
+* If your extension contains common functionality that you want to share among multiple applications, you should create an addon that includes one or more hooks. You can then add the addon to all applications that should use the functionality.
 
 For both options, you must create one or more hooks first. The options differ in how you add these hooks to your application.
 

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -12,13 +12,13 @@ This will create a container which exposes the TCP port `5559` on its private ad
 
     amc launch -s +adb --enable-graphics -r
 
-[note type="information" status="Hint"]If you're wondering about the syntax of the command used to launch a container, see [How to launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327).[/note]
+[note type="information" status="Tip"]If you're wondering about the syntax of the command used to launch a container, see [How to launch a container](https://discourse.ubuntu.com/t/launch-a-container/24327).[/note]
 
 If you want to run the Appium tests against an Android application managed by AMS (see [How to create an application](https://discourse.ubuntu.com/t/create-an-application/24198)) you can start a regular container instead:
 
     amc launch -s adb --enable-graphics --disable-watchdog app
 
-[note type="information" status="Hint"]The `--disable-watchdog` argument is important as by default Anbox prevents Android from switching its foreground application and terminates when the application is stopped. To prevent this we need to disable the watchdog which is responsible for this.[/note]
+[note type="information" status="Important"]The `--disable-watchdog` argument is important because by default, Anbox prevents Android from switching its foreground application and terminates when the application is stopped. To prevent this, we need to disable the watchdog.[/note]
 
 Once the container is up and running, you can get its private IP address and the exposed port for the ADB service endpoint with the `amc ls` command:
 

--- a/howto/install/high-availability.md
+++ b/howto/install/high-availability.md
@@ -12,8 +12,8 @@ For example, to go from 1 to 5 AMS units, you would run the following:
 
     juju add-unit ams -n 4
 
-[note type="information" status="Hint"]
-By default Juju allocates small machines to limit costs, but you can request better resources by [enforcing constraints](https://juju.is/docs/olm/constraints):
+[note type="information" status="Tip"]
+By default, Juju allocates small machines to limit costs but you can request better resources by [enforcing constraints](https://juju.is/docs/olm/constraints):
 
 `juju set-constraints anbox-stream-gateway cores=4 memory=8GB`
 
@@ -83,8 +83,7 @@ anbox-stream-gateway/2      active    idle   4       10.212.218.136  4000/tcp,70
 
 ## Scaling down
 
-Scaling down can be done by [removing units via Juju](https://juju.is/docs/scaling-applications#heading--scaling-down).
-Here you have to specifically target the unit you want to remove:
+Scaling down can be done by [removing units via Juju](https://juju.is/docs/scaling-applications#heading--scaling-down). You have to specifically target the unit that you want to remove:
 
     juju remove-unit anbox-stream-agent/2
 

--- a/howto/install/landing.md
+++ b/howto/install/landing.md
@@ -1,5 +1,5 @@
 The guides in this section describe how to install Anbox Cloud.
 
-[note type="information" status="Note"]There is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702) or the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial.[/note]
+It is important to remember that there is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702) or the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial.
 
-Make sure to check the [Requirements](https://discourse.ubuntu.com/t/installation-requirements/17734) before you start your installation.
+Also, make sure to check the [Requirements](https://discourse.ubuntu.com/t/installation-requirements/17734) before you start your installation.

--- a/howto/manage/ams-access.md
+++ b/howto/manage/ams-access.md
@@ -43,8 +43,8 @@ To use a CA certificate, complete the following steps:
 4. For each client, generate a client key and certificate based on the CA certificate. You should use the same method for this as you did in the first step.
 5. Copy the generated credentials to the client machine:
 
-   - Copy the client certificate to `$HOME/snap/amc/current/client/client.crt`.
-   - Copy the client key to `$HOME/snap/amc/current/client/client.key`
+   * Copy the client certificate to `$HOME/snap/amc/current/client/client.crt`.
+   * Copy the client key to `$HOME/snap/amc/current/client/client.key`
 
 ## Expose the AMS HTTPS service
 
@@ -62,7 +62,7 @@ After setting up the security certificates, configure AMC to connect to the remo
 
     amc remote add <your remote name> https://<IP address of the AMS machine>:8444
 
-[note type="information" status="Hint"]If you haven't changed the port AMS is listening on, it's 8444 by default.[/note]
+[note type="information" status="Tip"]If you haven't changed the port AMS is listening on, it's 8444 by default.[/note]
 
 The command connects to AMS and shows you the fingerprint of the server certificate. If it matches what you expect, acknowledge the fingerprint by typing "yes".
 

--- a/howto/manage/images.md
+++ b/howto/manage/images.md
@@ -56,7 +56,7 @@ Images that are synchronised from the image server are marked as immutable. To d
 
 If you're not using `--force`, the command will fail.
 
-[note type="information" status="Hint"]Note that unless you have only one image left, you cannot delete an image that is marked as default. You must set a new default image first.[/note]
+[note type="information" status="Note"]Unless you have only one image left, you cannot delete an image that is marked as default. You must set a new default image first.[/note]
 
 ### Delete an image version
 
@@ -78,6 +78,6 @@ For instance, to fetch the arm64 Android 11 image of the 1.11.2 release:
 
 You can then use the `foobar` image as you would any other image.
 
-[note type="information" status="Tip"]
+[note type="information" status="Important"]
 Image updates contain important security patches and optimisations. Use older images only when strictly necessary.
 [/note]

--- a/howto/manage/web-dashboard.md
+++ b/howto/manage/web-dashboard.md
@@ -13,7 +13,7 @@ The dashboard comes pre-installed when you deploy [Anbox Cloud with the streamin
 
 To access the dashboard, go to `https://<your-machine-address>/`.
 
-[note type="information" status="Hint"]The dashboard uses self-signed certificates. You might see a warning from your browser and have to accept the certificates manually.[/note]
+[note type="information" status="Note"]The dashboard uses self-signed certificates. You might see a warning from your browser and have to accept the certificates manually.[/note]
 
 ### Granting access
 
@@ -67,9 +67,7 @@ Note that more advanced scenarios might not yet be possible via the dashboard an
 
 ### Streaming applications
 
-The dashboard comes with in-browser streaming capabilities through WebRTC.
-
-[note type="information" status="Note"]The dashboard uses the [Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk) under the hood.[/note]
+The dashboard comes with in-browser streaming capabilities through WebRTC. It uses the [Streaming SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk) under the hood.
 
 You can select any application you previously created and start a streaming session.
 

--- a/howto/stream/access.md
+++ b/howto/stream/access.md
@@ -47,4 +47,4 @@ curl -X GET https://20.234.75.29:4000/1.0/sessions \
 curl -X GET https://20.234.75.29:4000/1.0/sessions?api_token=AgEUYW5ib3...QSyzaA_GHLYQ
 ```
 
-[note type="information" status="Hint"]The Anbox Stream SDK handles the token automatically for all its requests.[/note]
+[note type="information" status="Note"]The Anbox Stream SDK handles the token automatically for all its requests.[/note]

--- a/howto/stream/oob-data.md
+++ b/howto/stream/oob-data.md
@@ -2,10 +2,10 @@ Enabling out-of-band (OOB) data transmission between an Android application and 
 
 Anbox Cloud provides two versions of this OOB data exchange:
 
-- [Version 2](#oob-v2) provides a full-duplex bidirectional data transmission mode in which data can flow in both directions at the same time.
+* [Version 2](#oob-v2) provides a full-duplex bidirectional data transmission mode in which data can flow in both directions at the same time.
 
   Use this version if you start your implementation now. If you already have an existing implementation, you should plan to update it to use version 2.
-- [Version 1](#oob-v1) enables Android application developers to trigger an action from an Android application running in a container and forward it to a WebRTC client through the Anbox WebRTC platform. When Anbox receives the action, as one peer of the WebRTC platform, the action is propagated from Anbox to the remote peer (the WebRTC client) through a WebRTC data channel. The client can then react to the action received from the remote peer and respond accordingly on the UI.
+* [Version 1](#oob-v1) enables Android application developers to trigger an action from an Android application running in a container and forward it to a WebRTC client through the Anbox WebRTC platform. When Anbox receives the action, as one peer of the WebRTC platform, the action is propagated from Anbox to the remote peer (the WebRTC client) through a WebRTC data channel. The client can then react to the action received from the remote peer and respond accordingly on the UI.
 
   This version supports only half-duplex data transmission. It allows sending data from an Android application to a WebRTC client through the Anbox WebRTC platform, but it is not possible to receive data from the WebRTC client to an Android application.
 
@@ -14,8 +14,8 @@ The support for [version 1](#oob-v1) of the out-of-band data exchange between an
 [/note]
 
 See the instructions for exchanging OOB data using a specific implementation version below:
-- [Version 2](#oob-v2)
-- [Version 1](#oob-v1)
+* [Version 2](#oob-v2)
+* [Version 1](#oob-v1)
 
 <a name="oob-v2"></a>
 ## Version 2
@@ -110,9 +110,9 @@ A trivial example to simulate the data transmission between an Anbox container a
 
 To build up the communication bridge between an Android application and the Anbox WebRTC platform, Anbox Cloud provides a system daemon named `anbox-webrtc-data-proxy`. This daemon is responsible for:
 
- - Accepting connection requests from an Android application
- - Connecting to one specific data channel via the Unix domain socket exposed by the Anbox WebRTC platform
- - Passing the connected socket as a file descriptor to the Android application
+ * Accepting connection requests from an Android application
+ * Connecting to one specific data channel via the Unix domain socket exposed by the Anbox WebRTC platform
+ * Passing the connected socket as a file descriptor to the Android application
 
 The `anbox-webrtc-data-proxy` system daemon runs in the Anbox container and registers an Android system service named `org.anbox.webrtc.IDataProxyService`. This service allows Android developers to easily make use of binder interprocess communication (IPC) for data communication between an Android application and the Anbox WebRTC platform through a file descriptor.
 
@@ -160,7 +160,7 @@ public class DataChannelEventReceiver extends BroadcastReceiver {
 
 There are two ways to access the `org.anbox.webrtc.IDataProxyService` from an Android application:
 
-- If you develop the application with Android studio, you can access the service by using Android's reflection API.
+* If you develop the application with Android studio, you can access the service by using Android's reflection API.
 
     ```
     IBinder getDataProxyService() {
@@ -181,7 +181,7 @@ There are two ways to access the `org.anbox.webrtc.IDataProxyService` from an An
     }
     ```
 
--  If you ship the Android application inside of the AOSP source tree and [build](https://source.android.com/docs/setup/build/building) it from there, you can use Android's hidden API to access the service.
+*  If you ship the Android application inside of the AOSP source tree and [build](https://source.android.com/docs/setup/build/building) it from there, you can use Android's hidden API to access the service.
 
     ```
     IBinder getDataProxyService() {

--- a/tut/getting-started.md
+++ b/tut/getting-started.md
@@ -5,8 +5,8 @@ The tutorial focuses on using the command line to work with Anbox Cloud, which g
 [note type="information" status="Important"]
 If you haven't installed Anbox Cloud or the Anbox Cloud Appliance yet, you must do so before you can continue with this tutorial. See the following documentation for installation instructions:
 
-- [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702)
-- [How to install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336)
+* [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702)
+* [How to install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336)
 [/note]
 
 ## 1. Run AMC


### PR DESCRIPTION
Discourse supports markdown notes now. This PR's scope includes the following actions:

- Check all the note banners in documentation. Republish the pages where notes are not in proper format.
- Convert notes of type Hint to Tip or other appropriate types. Keep it restricted to (Note, Important, Tip, Warning)
- Correct list formatting where required.