### PR TITLE
Github Actions: check for docs links not pointing to Discourse

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -1,0 +1,34 @@
+name: Check for links pointing to Anbox docs
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  check:
+    name: Check docs links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files_ignore: .github
+      
+      - name: Find Anbox Cloud docs links
+        id: find-anbox-cloud-docs-links
+        run: |
+          awk '{
+            # Use match explicitly to have access to retrieve column numbers
+            # with RSTART and RLENGTH
+            if (match($0, "anbox-cloud.io/docs") != 0)
+              print "::error file="FILENAME\
+                    ",line="FNR\
+                    ",col="RSTART\
+                    ",endColumn="RSTART+RLENGTH\
+                    ",title=Incorrect docs link"\
+                    "::Documentation links should point to Discourse"
+          }' ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
This adds a GitHub Action which checks for the presence of links to the Anbox Cloud documentation instead of Discourse.

This action only checks changed files (to avoid needing to change everything all at once)