### PR TITLE
Add content on how to collect troubleshooting information

### DIFF
--- a/howto/container/logs.md
+++ b/howto/container/logs.md
@@ -15,7 +15,7 @@ To follow the log and get automatic updates for new entries, add the `-f` argume
 
 This will show the logs and update the output whenever new entries are added.
 
-
+<a name="view-stored-logs"></a>
 ## View stored logs
 
 If a container fails to start or a runtime error occurs, AMS collects relevant log files from the container and makes them available for inspection.

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -10,6 +10,7 @@ The topics in this guide describe some commonly encountered problems with Anbox 
 
 If you still need help, use any of the following utilities to collect troubleshooting information and report an [issue](https://bugs.launchpad.net/anbox-cloud/+filebug).
 
+[note type="information" status="Note"] The following utilities could be applicable for the regular Anbox Cloud deployed with Juju or for the Anbox Cloud Appliance or both. The *Applies to* tag in each section indicates whether it is applicable to a particular variant. To know more about Anbox Cloud variants, see [Variants](https://discourse.ubuntu.com/t/17802#variants).[/note]
 
 ## Juju crashdump
 

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -13,9 +13,11 @@ If you still need help, use any of the following utilities to collect troublesho
 
 ## Juju crashdump
 
-*Applies to: Anbox Cloud, Anbox Cloud Appliance*
+*Applies to: Anbox Cloud*
 
-If you have the [`juju-crashdump` plugin](https://github.com/juju/juju-crashdump) installed, you can collect troubleshooting information from the deployment model. A Juju crash dump may include the following debugging information:
+If you have the [`juju-crashdump` plugin](https://github.com/juju/juju-crashdump) installed, you can collect troubleshooting information from the deployment model. The Juju crash dump gives you a high level overview of the issue and is the recommended option to provide debugging information when you report an issue with your Anbox Cloud deployment.
+
+A Juju crash dump may include the following debugging information:
 * Additional information provided by the Anbox Cloud charms
 * Information about any Anbox containers that crashed
 
@@ -24,6 +26,14 @@ Use the following command to generate a crash dump:
     juju crashdump -s -a debug-layer 
 
 The Anbox Management Service (AMS) charm implements the `debug-layer` addon which will add a `debug-*.tar.gz` archive to the crash dump for the AMS units. The tarball may contain container logs for the containers that are in `error` state in AMS and other information about the Anbox runtime process.
+
+## `anbox-cloud-appliance.buginfo` command
+
+*Applies to: Anbox Cloud Appliance*
+
+Use the `anbox-cloud-appliance.buginfo` command to obtain debugging information for issues with the Anbox Cloud Appliance.
+
+This is the recommended option to provide debugging information when you report an issue with the Anbox Cloud Appliance.
 
 ## Anbox Cloud bug report utility
 

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -11,7 +11,7 @@ The topics in this guide describe some commonly encountered problems with Anbox 
 If you still need help, use any of the following utilities to collect troubleshooting information and report an [issue](https://bugs.launchpad.net/anbox-cloud/+filebug).
 
 
-# Juju crashdump
+## Juju crashdump
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance*
 
@@ -25,7 +25,7 @@ Use the following command to generate a crash dump:
 
 The Anbox Management Service (AMS) charm implements the `debug-layer` addon which will add a `debug-*.tar.gz` archive to the crash dump for the AMS units. The tarball may contain container logs for the containers that are in `error` state in AMS and other information about the Anbox runtime process.
 
-# Anbox Cloud bug report utility
+## Anbox Cloud bug report utility
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance since 1.16.0*
 
@@ -41,7 +41,7 @@ amc exec <container_id> -- bash -c 'cat "$(anbox-bug-report)"' > "<target_file>"
 This command builds a zip archive that contains the container report. It then
 saves it to the local `<target_file>`. This process might take a few seconds.
 
-# Stored container logs
+## Stored container logs
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance*
 

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -47,4 +47,4 @@ saves it to the local `<target_file>`. This process might take a few seconds.
 
 If a container fails to start or a runtime error occurs, AMS collects relevant log files from the container and makes them available for inspection. 
 
-Use `amc show <container_id>` command to list the available logs. See **Stored container logs** section in [How to view container logs](https://discourse.ubuntu.com/t/how-to-view-the-container-logs/24329) for an example of such a stored log.
+Use `amc show <container_id>` command to list the available logs. See [View stored logs](https://discourse.ubuntu.com/t/how-to-view-the-container-logs/24329#view-stored-logs) for an example of such a stored log.

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -1,11 +1,31 @@
 The topics in this guide describe some commonly encountered problems with Anbox Cloud and provide instructions for resolving them. If you encounter an issue with Anbox Cloud, check if any of the following scenarios help in resolving your issue.
 
+[note type="information" status="Note"]If the deployment is older than 3 months, you must upgrade Anbox Cloud to the latest version and see if the required fixes are already part of the upgrade. See [How to upgrade Anbox Cloud](https://discourse.ubuntu.com/t/how-to-upgrade-anbox-cloud/17750) for upgrade instructions.
+[/note]
+
 * [Troubleshoot issues with initial setup](https://discourse.ubuntu.com/t/troubleshoot-issues-with-initial-setup/35704)
 * [Troubleshoot container failures](https://discourse.ubuntu.com/t/troubleshoot-container-failures/35703)
 * [Troubleshoot issues with application creation](https://discourse.ubuntu.com/t/troubleshoot-issues-with-application-creation/35702)
 * [Troubleshoot issues with LXD clustering](https://discourse.ubuntu.com/t/troubleshoot-issues-with-lxd-clustering/35705)
 
-If you still need help, use the following instructions to collect troubleshooting information from the container and report an issue.
+If you still need help, use any of the following utilities to collect troubleshooting information and report an [issue](https://bugs.launchpad.net/anbox-cloud/+filebug).
+
+
+# Juju crashdump
+
+*Applies to: Anbox Cloud, Anbox Cloud Appliance*
+
+If you have the [`juju-crashdump` plugin](https://github.com/juju/juju-crashdump) installed, you can collect troubleshooting information from the deployment model. A Juju crash dump may include the following debugging information:
+* Additional information provided by the Anbox Cloud charms
+* Information about any Anbox containers that crashed
+
+Use the following command to generate a crash dump:
+
+    juju crashdump -s -a debug-layer 
+
+The Anbox Management Service (AMS) charm implements the `debug-layer` addon which will add a `debug-*.tar.gz` archive to the crash dump for the AMS units. The tarball may contain container logs for the containers that are in `error` state in AMS and other information about the Anbox runtime process.
+
+# Anbox Cloud bug report utility
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance since 1.16.0*
 
@@ -20,3 +40,11 @@ amc exec <container_id> -- bash -c 'cat "$(anbox-bug-report)"' > "<target_file>"
 
 This command builds a zip archive that contains the container report. It then
 saves it to the local `<target_file>`. This process might take a few seconds.
+
+# Stored container logs
+
+*Applies to: Anbox Cloud, Anbox Cloud Appliance*
+
+If a container fails to start or a runtime error occurs, AMS collects relevant log files from the container and makes them available for inspection. 
+
+Use `amc show <container_id>` command to list the available logs. See **Stored container logs** section in [How to view container logs](https://discourse.ubuntu.com/t/how-to-view-the-container-logs/24329) for an example of such a stored log.


### PR DESCRIPTION
This PR adds additional information about how to collect troubleshooting information from the Anbox deployment and from containers before filing a bug.