### PR TITLE
ci: ignore announcements dir in check docs link

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -16,7 +16,9 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v35
         with:
-          files_ignore: .github
+          files_ignore: |
+            .github
+            announcements
       
       - name: Find Anbox Cloud docs links
         id: find-anbox-cloud-docs-links


### PR DESCRIPTION
This add the announcements dir to the list of ignored dirs as it follows different rules than the other dirs.