### PR TITLE
Add content for AC-1321

### DIFF
--- a/howto/application/update.md
+++ b/howto/application/update.md
@@ -106,8 +106,8 @@ Each version takes up space on the LXD nodes. To free up space and remove old an
 
 The command will ask for your approval before the version is removed as it might affect your users. If you want to bypass the check, you can add the `--yes` flag to the command.
 
-<a name="disable-automatic-updates"></a>
-## Disable automatic application updates
+<a name="configure-automatic-updates"></a>
+## Configure automatic application updates
 
 *since 1.11.0*
 

--- a/howto/update/upgrade-anbox.md
+++ b/howto/update/upgrade-anbox.md
@@ -168,6 +168,8 @@ LXD images are automatically being fetched by AMS from the image server once the
 
 Existing applications will be automatically updated by AMS as soon as the new image is uploaded. Watch out for new versions being added for any of the existing applications based on the new image version.
 
-You can check for the status of an existing application by running
+You can check for the status of an existing application by running:
 
     amc application show <application id or name>
+
+In case automatic updates are disabled for applications, AMS cannot update the application. See [Configure automatic application updates](https://discourse.ubuntu.com/t/24201#configure-automatic-updates) to enable automatic updates or to manually update the applications.

--- a/howto/update/upgrade-appliance.md
+++ b/howto/update/upgrade-appliance.md
@@ -15,7 +15,11 @@ In the command output above the `update-available` field indicates an update is 
 
     anbox-cloud-appliance upgrade
 
-The appliance will perform now all necessary steps to upgrade to the newer available version. You can watch for progress on the web interface
+The appliance will now perform all necessary steps to upgrade to the newer available version. 
+
+[note type="information" status="Note"]In case automatic updates are disabled for applications, Anbox Management Service (AMS) cannot update the application. See [Configure automatic application updates](https://discourse.ubuntu.com/t/24201#configure-automatic-updates) to enable automatic updates or to manually update the applications.[/note]
+
+You can watch the upgrade progress on the web interface:
 
 ![Upgrade the appliance|690x435](https://assets.ubuntu.com/v1/1093e239-update_appliance.png)
 

--- a/ref/ams-configuration.yaml
+++ b/ref/ams-configuration.yaml
@@ -22,7 +22,7 @@ all:
       If set to `true`, AMS automatically updates applications
       whenever any dependencies (parent image, addons, global
       configuration) change. `false` disables this. See
-      [Disable automatic application updates](https://discourse.ubuntu.com/t/update-an-application/24201#disable-automatic-updates).
+      [Configure automatic application updates](https://discourse.ubuntu.com/t/update-an-application/24201#configure-automatic-updates).
   application.default_abi:
     type: "string"
     default: "-"


### PR DESCRIPTION
* Rename title from Disable automatic updates to Configure automatic updates as the section contains information about both disable and enable automatic updates.

* Fix instances of old title and anchors.

* Add pointer to 'Configure automatic updates for applications' to 'Upgrade Anbox Cloud' and 'Upgrade Anbox Cloud Appliance' topics.