### PR TITLE
Revert unschedulable for PATCH method of 1.0/nodes endpoint

### DIFF
--- a/ref/ams-http-api.md
+++ b/ref/ams-http-api.md
@@ -2044,7 +2044,7 @@ Supported update field            |   Description
 `gpu_slots` | (number) Slots on the GPU available to containers
 `gpu_encoder_slots` | (number) Slots on the GPU encoders available to containers
 `tags` | (string) User defined tags
-`unschedulable` | (Boolean) Whether this LXD node is schedulable by AMS
+`unscheduable` | (Boolean) Whether this LXD node is schedulable by AMS. (The typo in the field name will be fixed in an upcoming release.)
 
 A sample payload as follows:
 


### PR DESCRIPTION
Based on a bug report, we found out that the `unschedulable` correction was not done for `type NodePatch struct`. A [Jira ticket](https://warthogs.atlassian.net/browse/AC-1689) is tracking this issue. For now, the docs need to reflect the field name correctly.