### PR TITLE
Fix broken links

### DIFF
--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -82,7 +82,8 @@ If the APK file that you want to test is located in local folder or hosted on a 
 The above preset accepts either an absolute path to an APK or a URL.
 
 Finally you can start a new test session and run your test cases.
-For more details about Appium, please refer to the [official documentation](http://appium.io/docs/en/about-appium/getting-started/)
+
+For more details about Appium, please refer to the [Appium official documentation](http://appium.io)
 
 ### APK managed by AMS
 

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -83,7 +83,7 @@ The above preset accepts either an absolute path to an APK or a URL.
 
 Finally you can start a new test session and run your test cases.
 
-For more details about Appium, please refer to the [Appium official documentation](http://appium.io)
+For more details about Appium, please refer to the [Appium official documentation](https://appium.io)
 
 ### APK managed by AMS
 

--- a/howto/container/access.md
+++ b/howto/container/access.md
@@ -30,8 +30,8 @@ In the next sections, you will learn how to connect a container running on Anbox
 ### Install scrcpy
 
 Scrcpy is not available from the official Ubuntu repositories. Therefore, you must install scrcpy in one of the following ways:
-
-* Build scrcpy from the source by following the official [guide](https://github.com/Genymobile/scrcpy/blob/master/BUILD.md)
+<!-- wokeignore:rule=master -->
+* Build scrcpy from the source by following the official [guide](https://github.com/Genymobile/scrcpy/blob/master/doc/build.md)
 
 * Install scrcpy from the [Ubuntu snap store](https://snapcraft.io):
 

--- a/howto/install/high-availability.md
+++ b/howto/install/high-availability.md
@@ -1,7 +1,7 @@
 Anbox Cloud comes with support for High Availability (HA) for both Core and the Streaming Stack.
 Next to [Juju's support for high availability of the Juju controller](https://juju.is/docs/controller-high-availability), you can add HA for the [Anbox Management Service (AMS)](https://discourse.ubuntu.com/t/about-ams/24321) and the Anbox Stream Gateway to ensure fault tolerance and higher uptime.
 
-Enabling High Availability (HA for short) is achieved by [adding new units via Juju](https://juju.is/docs/scaling-applications).
+Enabling High Availability (HA for short) is achieved by [adding new units via Juju](https://juju.is/docs/olm/manage-applications#heading--scale-an-application).
 This will allocate a new machine, run new instances of the scaled application and configure the cluster automatically.
 
 Adding a unit is done with the following syntax:

--- a/ref/android-features.md
+++ b/ref/android-features.md
@@ -15,7 +15,7 @@ Anbox Cloud implements support for various features that Android has. The follow
 | Telephony / mobile connectivity | | |
 | Hardware-accelerated video decoding (H.264) | ✓ | |
 | Hardware-accelerated video encoding (H.264) | | |
-| [`fs-verity`](https://source.android.com/security/features/apk-verity) | | |
+| [`fs-verity`](https://www.kernel.org/doc/html/latest/filesystems/fsverity.html) | | |
 | [Disk encryption](https://source.android.com/security/encryption) | | |
 | [Verified Boot](https://source.android.com/security/verifiedboot) | | |
 | [Trusted Execution Environment (TEE)](https://source.android.com/security/trusty) | | |

--- a/ref/webrtc-streamer.md
+++ b/ref/webrtc-streamer.md
@@ -17,7 +17,7 @@ The configuration file uses the JSON format. It has the following structure:
 | `nvidia_h264.aq_strength` | integer | `0` | Strength of adaptive quantisation: a value from `1` (least aggressive) to `15` (most aggressive). `0` means the encoder will automatically decide. |
 | `nvidia_h264.preset` | integer | `0` | Preset to use (a value from `1` to `7`). `0` means Anbox will automatically decide. |
 
-See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/nvenc-video-encoder-api-prog-guide/index.html) documentation for more details on the `nvidia_h264` options.
+See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/) documentation for more details on the `nvidia_h264` options.
 
 <a name="video-bitrate-limits"/></a>
 ## Video bitrate limits

--- a/ref/webrtc-streamer.md
+++ b/ref/webrtc-streamer.md
@@ -17,7 +17,7 @@ The configuration file uses the JSON format. It has the following structure:
 | `nvidia_h264.aq_strength` | integer | `0` | Strength of adaptive quantisation: a value from `1` (least aggressive) to `15` (most aggressive). `0` means the encoder will automatically decide. |
 | `nvidia_h264.preset` | integer | `0` | Preset to use (a value from `1` to `7`). `0` means Anbox will automatically decide. |
 
-See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/nvenc-video-encoder-api-prog-guide/) documentation for more details on the `nvidia_h264` options.
+See the [NVENC Video Encoder API](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/nvenc-video-encoder-api-prog-guide/index.html) documentation for more details on the `nvidia_h264` options.
 
 <a name="video-bitrate-limits"/></a>
 ## Video bitrate limits

--- a/release-notes/1.10.0.md
+++ b/release-notes/1.10.0.md
@@ -14,7 +14,7 @@ Android 11 was released back in 2020 by Google and is now available and fully su
 
 ### All Charms and Bundles are now public
 
-In earlier Anbox Cloud versions the Juju charms and bundles for Anbox Cloud were only available after explicitly allowing access for user accounts. With 1.10 all charms and bundles are not available in the public on the Juju Charmstore. You can see all available charms and bundles [here](https://jaas.ai/u/anbox-charmers).
+In earlier Anbox Cloud versions the Juju charms and bundles for Anbox Cloud were only available after explicitly allowing access for user accounts. With 1.10 all charms and bundles are not available in the public on the Juju Charmstore. You can see all available charms and bundles [here](https://charmhub.io/?q=anbox+cloud).
 
 Please note that despite the charms being publicly available you still need a paid subscription for Ubuntu Advantage for Applications. In case you're interested, please [contact us](https://anbox-cloud.io/#request-form).
 
@@ -64,16 +64,16 @@ As announced with the [1.9.0 release](https://discourse.ubuntu.com/t/anbox-cloud
 
 ### Anbox Stream Gateway Dev UI
 
-The Anbox Stream Gateway Dev UI is now fully replaced with the [Anbox Cloud Dashboard](https://anbox-cloud.io/docs/manage/web-dashboard) and is no longer available. Trying to enable it with the `enable_dev_ui` charm configuration option on the `anbox-stream-gateway` charm will have no effect.
+The Anbox Stream Gateway Dev UI is now fully replaced with the [Anbox Cloud Dashboard](https://discourse.ubuntu.com/t/20871) and is no longer available. Trying to enable it with the `enable_dev_ui` charm configuration option on the `anbox-stream-gateway` charm will have no effect.
 
-If you haven't deployed the [Anbox Cloud Dashboard](https://anbox-cloud.io/docs/manage/web-dashboard) yet, you can do so with the following commands:
+If you haven't deployed the [Anbox Cloud Dashboard](https://discourse.ubuntu.com/t/20871) yet, you can do so with the following commands:
 
     $ juju depoy cs:~anbox-charmers/anbox-cloud-dashboard
     $ juju relate anbox-cloud-dashboard:gateway anbox-stream-gateway:client
     $ juju relate anbox-cloud-dashboard:certificates easyrsa:client
     $ juju relate anbox-cloud-dashboard:ams ams:rest-api
 
-The [Juju bundles](https://jaas.ai/u/anbox-charmers#bundles) for Anbox Cloud are updated and include the dashboard since 1.9.0
+The [Juju bundles](https://charmhub.io/?q=anbox+cloud+bundles) for Anbox Cloud are updated and include the dashboard since 1.9.0
 
 ## Known Issues
 

--- a/release-notes/1.11.2.md
+++ b/release-notes/1.11.2.md
@@ -24,4 +24,4 @@ Please see [component versions](https://anbox-cloud.io/docs/component-versions) 
 
 #### Upgrade instructions
 
-See [Upgrade Anbox Cloud](https://anbox-cloud.io/docs/installation/upgrading-from-previous-versions) or [Upgrade the Anbox Cloud Appliance](https://anbox-cloud.io/docs/howto/upgrade/upgrade-appliance) for instructions on how to update your Anbox Cloud deployment to the 1.11.2 release.
+See [Upgrade Anbox Cloud](https://discourse.ubuntu.com/t/17750) or [Upgrade the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/24186) for instructions on how to update your Anbox Cloud deployment to the 1.11.2 release.

--- a/requirements.md
+++ b/requirements.md
@@ -129,6 +129,6 @@ Some additional information:
 
 Applications not maintained by Anbox Cloud may have different hardware recommendations:
  - **etcd**: [Hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/)
- - **HAProxy** (load balancer for the Stream Gateway and the dashboard): [Installation](https://www.haproxy.com/documentation/hapee/latest/installation/getting-started/os-hardware/#hardware-requirements)
+ - **HAProxy** (load balancer for the Stream Gateway and the dashboard): [Installation](https://www.haproxy.com/documentation/hapee/latest/getting-started/hardware/)
 
 Please note that these are just baselines and should be adapted to your workload. No matter the application, [monitoring and tuning the performance](https://discourse.ubuntu.com/t/about-performance/29416) is always important.


### PR DESCRIPTION
* Fix broken links as automatically reported on ~docs mattermost channel

We can currently ignore discourse links vs docs links usage in release notes files. There is a mix of both. While discourse links help in reducing broken links, docs links redirect to the correct output format when users are reading the release notes. We need to come up with a strategy for this but that's a task for later and also best done iteratively as we edit files.