### PR TITLE
Add a pre-commit hook for checking doc links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,12 @@ repos:
     rev: v0.5.0
     hooks:
       - id: spellcheck
+  - repo: https://github.com/anbox-cloud/pre-commit-hooks
+    rev: 797fe47e86364afe21b7679f2dc309ee441a891d
+    hooks:
+      - id: anbox-cloud-docs-links-checker
+        exclude: |
+          (?x)^(
+            .github/.*
+            |release-notes/.*
+          )$

--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ review workflow on top.
   the spellchecker.
 * Navigate to the top-level directory of this repository and run `pre-commit install --install-hooks`.
 * The following checks are run automatically before every commit.
-  - Inclusive naming checks (`woke`).
-  - Spellcheck.
+  - Inclusive naming checks (`woke`)
+  - Spellcheck (`spellcheck`)
+  - Docs links checker (`anbox-cloud-docs-links-checker`)


### PR DESCRIPTION
Add a pre-commit hook that finds links pointing to `https://anbox-cloud.io/docs/...` instead of discourse and reports errors.