### PR TITLE
Resolve broken links reported by the link checker

### DIFF
--- a/howto/install/high-availability.md
+++ b/howto/install/high-availability.md
@@ -83,7 +83,7 @@ anbox-stream-gateway/2      active    idle   4       10.212.218.136  4000/tcp,70
 
 ## Scaling down
 
-Scaling down can be done by [removing units via Juju](https://juju.is/docs/scaling-applications#heading--scaling-down). You have to specifically target the unit that you want to remove:
+Scaling down can be done by [removing units via Juju](https://juju.is/docs/olm/manage-applications#heading--scale-an-application). You have to specifically target the unit that you want to remove:
 
     juju remove-unit anbox-stream-agent/2
 

--- a/release-notes/1.16.0.md
+++ b/release-notes/1.16.0.md
@@ -37,7 +37,7 @@ The Anbox [images](https://anbox-cloud.io/docs/ref/provided-images) include a ne
 To allow better fine-tuning of the WebRTC based streaming implementation in Anbox Cloud, 1.16 includes various small improvements:
 
 * Video bitrate limits can now be specified on a per resolution/frame rate level.
-* Additional options allow enabling NVIDIA-specific options for H.264 encoding ([adaptive quantisation](https://docs.nvidia.com/video-technologies/video-codec-sdk/nvenc-video-encoder-api-prog-guide/#adaptive-quantization-aq), [multi-pass frame encoding](https://docs.nvidia.com/video-technologies/video-codec-sdk/nvenc-video-encoder-api-prog-guide/#multi-pass-frame-phencoding)).
+* Additional options allow enabling NVIDIA-specific options for H.264 encoding ([adaptive quantisation](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/#adaptive-quantization-aq), [multi-pass frame encoding](https://docs.nvidia.com/video-technologies/video-codec-sdk/11.0/nvenc-video-encoder-api-prog-guide/#multi-pass-frame-phencoding)).
 * Audio and video are now sent on separate streams to improve playout delay on the client.
 * The benchmark utility can now provide statistics for minimum playout and jitter buffer delay.
 * TURN credentials for the container are now dynamically allocated and are no longer created with a constant lifetime.


### PR DESCRIPTION
A couple more broken links were reported by the web team's link checker. I believe the link checker stops at the first broken link for a file. So it does not catch all the broken links in one go but rather does it in iterations.