### PR TITLE
Change local machine mentions

### DIFF
--- a/howto/install-appliance/aws.md
+++ b/howto/install-appliance/aws.md
@@ -1,7 +1,7 @@
 You can install the Anbox Cloud Appliance on AWS in one of two ways:
 
 - Install through the AWS Marketplace. This is the recommended way, because this method simplifies the installation and deployment process and allows billing to be handled directly through AWS.
-- Install the Anbox Cloud Appliance snap on an AWS machine. This method is not recommended, but if you want to do it anyway, see the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial for instructions on how to install the snap.
+- Install the Anbox Cloud Appliance snap on an AWS machine. This method is not recommended, but if you want to do it anyway, see the [Install the Anbox Cloud Appliance on a dedicated machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial for instructions on how to install the snap.
 
 The following instructions guide you through all relevant steps to deploy the Anbox Cloud Appliance from the AWS Marketplace. For additional information, see the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/launching-instance.html) about launching an instance.
 

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -3,7 +3,7 @@ Anbox Cloud supports various public clouds, such as AWS, Azure and Google. To de
 See the following sections for detailed instructions. If you want to install Anbox Cloud on bare metal instead of a public cloud, see [How to deploy Anbox Cloud on bare metal](https://discourse.ubuntu.com/t/deploy-anbox-cloud-on-bare-metal/26378) instead.
 
 [note type="information" status="Note"]
-There are differences between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702) or the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial.
+There are differences between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702) or the [Install the Anbox Cloud Appliance on a dedicated machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial.
 [/note]
 
 ## Prerequisites

--- a/howto/install/landing.md
+++ b/howto/install/landing.md
@@ -1,5 +1,5 @@
 The guides in this section describe how to install Anbox Cloud.
 
-It is important to remember that there is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702) or the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial.
+It is important to remember that there is a difference between the full Anbox Cloud installation and the Anbox Cloud Appliance (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This section focuses on **Anbox Cloud**. For instructions on how to install the **Anbox Cloud Appliance**, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702) or the [Install the Anbox Cloud Appliance on a dedicated machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial.
 
 Also, make sure to check the [Requirements](https://discourse.ubuntu.com/t/installation-requirements/17734) before you start your installation.

--- a/howto/manage/web-dashboard.md
+++ b/howto/manage/web-dashboard.md
@@ -48,7 +48,7 @@ unit-anbox-cloud-dashboard-0:
 <a name="dashboard-access-appliance"></a>
 #### Register an Ubuntu One account in Anbox Cloud Appliance
 
-If you followed the instructions in the [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial or in [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702), you already registered your Ubuntu One account.
+If you followed the instructions in the [Install the Anbox Cloud Appliance on a dedicated machine](https://discourse.ubuntu.com/t/install-appliance/22681) tutorial or in [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702), you already registered your Ubuntu One account.
 
 To add more accounts, use the following command:
 

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -1,12 +1,12 @@
 The Anbox Cloud Appliance provides a deployment of Anbox Cloud to a single machine. This offering is well suited for initial prototype and small scale deployments.
 
 [note type="information" status="Note"]
-There are differences between the Anbox Cloud Appliance and the full Anbox Cloud installation (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This tutorial focuses on installing the **Anbox Cloud Appliance** on a local machine. To install the appliance on a cloud platform, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702).
+There are differences between the Anbox Cloud Appliance and the full Anbox Cloud installation (see [Variants](https://discourse.ubuntu.com/t/anbox-cloud-overview/17802#variants)). This tutorial focuses on installing the **Anbox Cloud Appliance** on a single dedicated machine. To install the appliance on a cloud platform, see [How to install the Anbox Cloud Appliance](https://discourse.ubuntu.com/t/how-to-install-the-anbox-cloud-appliance/29702).
 
 For instructions on how to install **Anbox Cloud**, see [How to install Anbox Cloud](https://discourse.ubuntu.com/t/install-anbox-cloud/24336).
 [/note]
 
-This tutorial guides you through the steps that are required to install and initialise the Anbox Cloud Appliance on your local machine from the [snap](https://snapcraft.io/anbox-cloud-appliance):
+This tutorial guides you through the steps that are required to install and initialise the Anbox Cloud Appliance on the machine from the [snap](https://snapcraft.io/anbox-cloud-appliance):
 
 1. [Check the prerequisites](#prerequisites)
 2. [Install the appliance](#install)

--- a/tut/landing.md
+++ b/tut/landing.md
@@ -1,6 +1,6 @@
 This section of our documentation helps you learn the installation process of the Anbox Cloud Appliance and go through the first steps of using Anbox Cloud. Our tutorials aim to make as few assumptions as possible and provide a learning experience as you begin using Anbox Cloud.
 
-* [Install the Anbox Cloud Appliance on your local machine](https://discourse.ubuntu.com/t/22681)
+* [Install the Anbox Cloud Appliance on a dedicated machine](https://discourse.ubuntu.com/t/22681)
 * [Get started with Anbox Cloud (web dashboard)](https://discourse.ubuntu.com/t/24958)
 * [Get started with Anbox Cloud (CLI)](https://discourse.ubuntu.com/t/17756) 
 * [Create an addon](https://discourse.ubuntu.com/t/25284)


### PR DESCRIPTION
Change "local machine" to "dedicated machine" wherever we talk about the Anbox Cloud appliance installation on a machine that is meant for Anbox Cloud.