### PR TITLE
Move AV1 encoding from future to supported

### DIFF
--- a/ref/sdks.md
+++ b/ref/sdks.md
@@ -78,7 +78,7 @@ Having these two components makes it easier to plug your own software in the SDK
 | Location support                                 |        ✓       |
 | Supported platforms                              |       All       |
 | Zero Copy rendering and decoding                 |        ✓       |
-| Supported video codecs                           | VP8, H.264      |
+| Supported video codecs                           | VP8, H.264, AV1 |
 
 ### Download and installation
 

--- a/ref/supported-video-codecs.md
+++ b/ref/supported-video-codecs.md
@@ -6,10 +6,8 @@ Currently, the following video codecs are supported:
 
  * H.264 - The use of H.264 requires a license from the [MPEG LA](https://www.mpegla.com/). Ensure you have the rights to stream H.264 encoded video content to your users.
  * VP8
-
-In the future we plan to add support for:
-
- * VP9
  * AV1
 
+In the future we plan to add support for VP9 as well.
+ 
 Availability of additional codecs depends on them being supported by the GPU vendors in their hardware encoding solutions or if a viable software encoding solution exists. See [Release roadmap](https://discourse.ubuntu.com/t/19359) for future versions of Anbox Cloud and planned features.

--- a/ref/supported-video-codecs.md
+++ b/ref/supported-video-codecs.md
@@ -8,6 +8,4 @@ Currently, the following video codecs are supported:
  * AV1 - Depending on the GPU model used in the deployment, AV1 hardware encoding is the default preference over H.264 on supported GPUs, such as NVIDIA Ada Lovelace Architecture-based GPUs like L4. Otherwise, it will fallback to AV1 software encoding.
  * VP8
 
-In the future we plan to add support for VP9 as well.
- 
 Availability of additional codecs depends on them being supported by the GPU vendors in their hardware encoding solutions or if a viable software encoding solution exists. See [Release roadmap](https://discourse.ubuntu.com/t/19359) for future versions of Anbox Cloud and planned features.

--- a/ref/supported-video-codecs.md
+++ b/ref/supported-video-codecs.md
@@ -5,8 +5,8 @@ Not all codecs are supported by one or more of the supported GPU models, neither
 Currently, the following video codecs are supported:
 
  * H.264 - The use of H.264 requires a license from the [MPEG LA](https://www.mpegla.com/). Ensure you have the rights to stream H.264 encoded video content to your users.
+ * AV1 - Depending on the GPU model used in the deployment, AV1 hardware encoding is the default preference over H.264 on supported GPUs, such as NVIDIA Ada Lovelace Architecture-based GPUs like L4. Otherwise, it will fallback to AV1 software encoding.
  * VP8
- * AV1
 
 In the future we plan to add support for VP9 as well.
  


### PR DESCRIPTION
This change should be published only with 1.19 updates.