### PR TITLE
Remove unsupported images

### DIFF
--- a/howto/manage/images.md
+++ b/howto/manage/images.md
@@ -18,17 +18,11 @@ You can see the synchronised images with the `amc image list` command:
 +----------------------+------------------------+--------+----------+--------------+---------+
 |          ID          |          NAME          | STATUS | VERSIONS | ARCHITECTURE | DEFAULT |
 +----------------------+------------------------+--------+----------+--------------+---------+
-| cbv37rfu3kvchoeai3kg | jammy:android12:arm64  | active | 1        | aarch64      | true    |
+| cgrqjd6k9eqlsruefcng | jammy:android13:arm64  | active | 1        | aarch64      | true    |
 +----------------------+------------------------+--------+----------+--------------+---------+
-| cbv384vu3kvchoeai3l0 | jammy:android11:arm64  | active | 1        | aarch64      | false   |
+| cgrqjnmk9eqlsruefco0 | jammy:android12:arm64  | active | 1        | aarch64      | false   |
 +----------------------+------------------------+--------+----------+--------------+---------+
-| cbv38gnu3kvchoeai3lg | jammy:android10:arm64  | active | 1        | aarch64      | false   |
-+----------------------+------------------------+--------+----------+--------------+---------+
-| cbv393nu3kvchoeai3m0 | bionic:android12:arm64 | active | 1        | aarch64      | false   |
-+----------------------+------------------------+--------+----------+--------------+---------+
-| cbv39mvu3kvchoeai3mg | bionic:android11:arm64 | active | 1        | aarch64      | false   |
-+----------------------+------------------------+--------+----------+--------------+---------+
-| cbv3a4vu3kvchoeai3n0 | bionic:android10:arm64 | active | 1        | aarch64      | false   |
+| cgrqk2uk9eqlsruefcog | jammy:android11:arm64  | active | 1        | aarch64      | false   |
 +----------------------+------------------------+--------+----------+--------------+---------+
 ```
 
@@ -38,7 +32,7 @@ The default image is used when you create an application without the `image` fie
 
 You can set any image as your default with the following command:
 
-    amc image switch bionic:android12:arm64
+    amc image switch jammy:android13:arm64
 
 Running `amc image list` will now show this image marked as default.
 
@@ -72,9 +66,9 @@ With every new Anbox Cloud release, updated images are published. By default, th
 
     amc image add <local image name> <remote image name>@<release>
 
-For instance, to fetch the arm64 Android 11 image of the 1.11.2 release:
+For instance, to fetch the arm64 Android 13 image of the 1.18.0 release:
 
-    amc image add foobar bionic:android11:arm64@1.11.2
+    amc image add foobar jammy:android13:arm64@1.18.0
 
 You can then use the `foobar` image as you would any other image.
 

--- a/howto/monitor/monitor-status.md
+++ b/howto/monitor/monitor-status.md
@@ -41,13 +41,13 @@ Complete the following steps to deploy Anbox Cloud with the reference monitoring
      - ['nrpe', 'nagios']
    machines:
      '0':
-       series: bionic
+       series: jammy
        constraints: "cpu-cores=4 mem=4G root-disk=40G"
      '1':
-       series: bionic
+       series: jammy
        constraints: "cpu-cores=8 mem=16G root-disk=50G"
      '2':
-       series: bionic
+       series: jammy
        constraints: "cpu-cores=2 mem=8G root-disk=10G"
    ```
    [/Details]
@@ -73,13 +73,13 @@ Complete the following steps to deploy Anbox Cloud with the reference monitoring
      - ['coturn', 'nrpe:nrpe-external-master']
    machines:
      '0':
-       series: bionic
+       series: jammy
        constraints: "cpu-cores=4 mem=4G root-disk=40G"
      '1':
-       series: bionic
+       series: jammy
        constraints: "cpu-cores=8 mem=16G root-disk=50G"
      '2':
-       series: bionic
+       series: jammy
        constraints: "cpu-cores=2 mem=8G root-disk=10G"
    ```
    [/Details]

--- a/ref/provided-images.md
+++ b/ref/provided-images.md
@@ -18,10 +18,10 @@ The following table lists supported images available on the official image serve
 ## Deprecated images
 The following table lists the images that are available on the official image server but are deprecated. They will become unsupported after two releases.
 
-| Name                        | Android Version | Ubuntu Version | Available since |
-|-----------------------------|-----------------|----------------|---------------|
-| `jammy:android11:amd64`     | 11              | 22.04          | 1.14 |
-| `jammy:android11:arm64`     | 11              | 22.04          | 1.14 |
+| Name                        | Android Version | Ubuntu Version | Available since | Deprecated since |
+|-----------------------------|-----------------|----------------|-----------------|--------------------|
+| `jammy:android11:amd64`     | 11              | 22.04          | 1.14            | 1.19 |
+| `jammy:android11:arm64`     | 11              | 22.04          | 1.14            | 1.19 |
 
 ## Image support
 

--- a/ref/provided-images.md
+++ b/ref/provided-images.md
@@ -1,36 +1,32 @@
-Anbox Cloud provides images based on different Android versions and different architectures (amd64, arm64). AMS manages these images, which can be individually selected by applications. When an image is updated, all applications using the image are automatically updated and rebased on the new image version.
+Anbox Cloud provides images based on different Android versions and different architectures (amd64, arm64). Anbox Management Service (AMS) manages these images, which can be individually selected by applications. When an image is updated, all applications using the image are automatically updated and rebased on the new image version.
 
 Officially released images are available from the [official image server](https://images.anbox-cloud.io) hosted by Canonical. It is currently not possible to build custom images for Anbox Cloud.
 
 Anbox Cloud images are regular [Ubuntu cloud images](https://cloud-images.ubuntu.com/) where Anbox Cloud and its dependencies are installed. Unnecessary packages are removed to improve images size, boot time and security.
 
-## Official images
+## Supported images
 
-The following table lists all images that are available on the official image server, along with their corresponding Android and Ubuntu versions. Please note the support status for each of the images.
+The following table lists supported images available on the official image server, along with their corresponding Android and Ubuntu versions.
 
-| Name                        | Android Version | Ubuntu Version | Support Status     | Available since |
-|-----------------------------|-----------------|----------------|------------|---------------|
-| `jammy:android13:amd64`     | 13              | 22.04          | supported | 1.16 |
-| `jammy:android13:arm64`     | 13              | 22.04          | supported | 1.16 |
-| `jammy:android12:amd64`     | 12              | 22.04          | supported | 1.14 |
-| `jammy:android12:arm64`     | 12              | 22.04          | supported | 1.14 |
-| `jammy:android11:amd64`     | 11              | 22.04          | supported | 1.14 |
-| `jammy:android11:arm64`     | 11              | 22.04          | supported | 1.14 |
-| `jammy:android10:amd64`     | 10              | 22.04          | supported | 1.14 |
-| `jammy:android10:arm64`     | 10              | 22.04          | supported | 1.14 |
-| `bionic:android12:amd64`    | 12              | 18.04          | deprecated as of 1.16 | 1.12 |
-| `bionic:android12:arm64`    | 12              | 18.04          | deprecated as of 1.16 | 1.12 |
-| `bionic:android11:amd64`    | 11              | 18.04          | deprecated as of 1.16 | 1.10 |
-| `bionic:android11:arm64`    | 11              | 18.04          | deprecated as of 1.16 | 1.10 |
-| `bionic:android10:amd64`    | 10              | 18.04          | deprecated as of 1.16 | 1.0  |
-| `bionic:android10:arm64`    | 10              | 18.04          | deprecated as of 1.16  | 1.0  |
-| `bionic:android7:amd64`     | 7               | 18.04          | unsupported as of 1.10 | 1.0 |
-| `bionic:android7:arm64`     | 7               | 18.04          | unsupported as of 1.10 | 1.0 |
+| Name                        | Android Version | Ubuntu Version | Available since |
+|-----------------------------|-----------------|----------------|---------------|
+| `jammy:android13:amd64`     | 13              | 22.04          | 1.16 |
+| `jammy:android13:arm64`     | 13              | 22.04          | 1.16 |
+| `jammy:android12:amd64`     | 12              | 22.04          | 1.14 |
+| `jammy:android12:arm64`     | 12              | 22.04          | 1.14 |
+
+## Deprecated images
+The following table lists the images that are available on the official image server but are deprecated. They will become unsupported after two releases.
+
+| Name                        | Android Version | Ubuntu Version | Available since |
+|-----------------------------|-----------------|----------------|---------------|
+| `jammy:android11:amd64`     | 11              | 22.04          | 1.14 |
+| `jammy:android11:arm64`     | 11              | 22.04          | 1.14 |
 
 ## Image support
 
-Anbox Cloud provides images based on two different Ubuntu versions, currently 18.04 (bionic) and 22.04 (jammy). The bionic images are deprecated and will receive their last update with the Anbox Cloud 1.18 release.
+Currently, Anbox Cloud provides images based on Ubuntu 22.04 (jammy). Deprecations, if any, are announced at least two releases in advance.
 
-Android versions are supported as long as Google provides security updates for the respective version. This means that the Android 10 images will be deprecated in Anbox Cloud 1.17 and will be dropped with Anbox Cloud 1.19. The `bionic:android7:arm64` and `bionic:android7:amd64` images are not receiving Android security updates anymore as Google stopped supporting Android 7 in 2019. They are listed only for legacy reasons and have been dropped with Anbox Cloud 1.10 in April 2021.
+Android versions are supported as long as Google provides security updates for the respective versions.
 
-Deprecations are announced at least two releases in advance.
+

--- a/tut/getting-started.md
+++ b/tut/getting-started.md
@@ -40,17 +40,11 @@ Next, check whether AMS has synchronised all images from the Canonical hosted im
 +----------------------+------------------------+--------+----------+--------------+---------+
 |          ID          |          NAME          | STATUS | VERSIONS | ARCHITECTURE | DEFAULT |
 +----------------------+------------------------+--------+----------+--------------+---------+
-| caa6s5l07mps24asmii0 | jammy:android12:arm64  | active | 1        | aarch64      | true    |
+| cgrqjd6k9eqlsruefcng | jammy:android13:arm64  | active | 1        | aarch64      | true    |
 +----------------------+------------------------+--------+----------+--------------+---------+
-| caa6scl07mps24asmiig | jammy:android11:arm64  | active | 1        | aarch64      | false   |
+| cgrqjnmk9eqlsruefco0 | jammy:android12:arm64  | active | 1        | aarch64      | false   |
 +----------------------+------------------------+--------+----------+--------------+---------+
-| caa6sil07mps24asmij0 | jammy:android10:arm64  | active | 1        | aarch64      | false   |
-+----------------------+------------------------+--------+----------+--------------+---------+
-| caa6sol07mps24asmijg | bionic:android12:arm64 | active | 1        | aarch64      | false   |
-+----------------------+------------------------+--------+----------+--------------+---------+
-| caa6t2d07mps24asmik0 | bionic:android11:arm64 | active | 1        | aarch64      | false   |
-+----------------------+------------------------+--------+----------+--------------+---------+
-| caa6ta507mps24asmikg | bionic:android10:arm64 | active | 1        | aarch64      | false   |
+| cgrqk2uk9eqlsruefcog | jammy:android11:arm64  | active | 1        | aarch64      | false   |
 +----------------------+------------------------+--------+----------+--------------+---------+
 ```
 


### PR DESCRIPTION
* Removed bionic images and jammy android 10 images from the supported list
* Changed mentions of bionic to a more recent example.

<s>Pending query: The mentions of bionic in https://anbox-cloud.io/docs/howto/monitor/monitor-status. Can they be just changed to jammy because it is part of the nagios configuration?</s>