### PR TITLE
Add documentation to enable `anbox-cloud` service

### DIFF
--- a/tut/getting-started.md
+++ b/tut/getting-started.md
@@ -17,7 +17,7 @@ How and where to run `amc` depends on your use case:
 - If you are running the Anbox Cloud Appliance on AWS, `amc` is already installed on the machine that runs the appliance. Log on to that machine to run `amc`.
 
   Note that you must use the user name `ubuntu` and provide the path to your private key file when connecting. See [Connect to your Linux instance using SSH](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html) for instructions on how to connect.
-- If you are running the Anbox Cloud Appliance on a physical or virtual machine, log on to that machine and ensure that you have [installed the additional tools](https://discourse.ubuntu.com/t/install-appliance/22681#additional-tools).
+- If you are running the Anbox Cloud Appliance on a physical or virtual machine, log on to that machine and ensure that you have [enabled the `anbox-cloud` service using the Ubuntu Pro client](https://discourse.ubuntu.com/t/22681#enable-anbox-service).
 - If you are running a full Anbox Cloud deployment, access the `ams/0` machine to run `amc`. You can do this by opening an SSH session with the `juju` command:
 
         juju ssh ams/0

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -53,11 +53,11 @@ On your machine, run the following command to install the Anbox Cloud Appliance 
 Running this command does the following:
 
 1. Installs the following tools and dependencies, if they are not installed already:
-    * snapd
-    * Anbox Management Client (AMC)
-    * LXD
+    * [snapd](https://snapcraft.io/snapd)
+    * [Anbox Management Client (AMC)](https://snapcraft.io/amc)
+    * [LXD](https://snapcraft.io/lxd)
 
-        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `latest/stable` track. If LXD is already installed but the version is older than 5.0, run `snap refresh --channel=5.0/stable lxd` to update it.[/note]
+        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `5.0/stable` track. If LXD is already installed but the version is earlier than 5.0, run `snap refresh --channel=5.0/stable lxd` to update it. However, if LXD version is later than 5.0, you cannot downgrade it.[/note]
 
 1. Installs `anbox-cloud-appliance` snap from the `latest/stable` track.
 1. Configures the `apt` repositories for Anbox Cloud.

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -57,7 +57,7 @@ Running this command does the following:
     * [Anbox Management Client (AMC)](https://snapcraft.io/amc)
     * [LXD](https://snapcraft.io/lxd)
 
-        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `5.0/stable` track. If LXD is already installed but the version is earlier than 5.0, run `snap refresh --channel=5.0/stable lxd` to update it. However, if LXD version is later than 5.0, you cannot downgrade it.[/note]
+        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `5.0/stable` track by default. If LXD is already installed but the version is earlier than 5.0, run `snap refresh --channel=5.0/stable lxd` to update it. However, if LXD version is later than 5.0, [do not downgrade it as it may render LXD unusable](https://documentation.ubuntu.com/lxd/en/latest/installing/#upgrade-lxd).[/note]
 
 1. Installs `anbox-cloud-appliance` snap from the `latest/stable` track.
 1. Configures the `apt` repositories for Anbox Cloud.

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -29,27 +29,13 @@ The following instructions guide you through all relevant steps to install the A
 
 ### 1. Update your system
 
-Run the following commands to ensure that all installed packages on your system are up-to-date:
+On your machine, run the following commands to ensure that all installed packages on your system are up-to-date:
 
     sudo apt update
     sudo apt upgrade
 
-### 2. Install dependencies
-
-The Anbox Cloud Appliance requires LXD >= 5.0. Check which version you have currently installed:
-
-    lxd --version
-
-If LXD is not installed, run:
-
-    snap install --channel=5.0/stable lxd
-
-If LXD is already installed but the version is older than 5.0, run:
-
-    snap refresh --channel=5.0/stable lxd
-
 <a name="attach-ubuntu-pro"></a>
-### 3. Attach your machine to the Ubuntu Pro subscription
+### 2. Attach your machine to the Ubuntu Pro subscription
 
 The Anbox Cloud Appliance requires a valid Ubuntu Pro subscription.
 
@@ -57,16 +43,24 @@ Before installing the appliance, you must attach the machine on which you want t
 
     sudo ua attach <pro_token>
 
-### 4. Install the snap
+<a name="enable-anbox-service"></a>
+### 3. Enable the `anbox-cloud` service using the Ubuntu Pro client.
 
-Run the following command to install the `anbox-cloud-appliance` snap, which handles the installation and deployment of the Anbox Cloud Appliance:
+On your machine, run the following command to install the Anbox Cloud Appliance and additional dependencies.
 
-    sudo snap install --classic anbox-cloud-appliance
+    pro enable anbox-cloud
 
-<a name="additional-tools"></a>
-### 5. Install additional tools
+Running this command does the following:
 
-Run `sudo snap install amc` to install the Anbox Management Client (AMC).
+1. Install the following tools and dependencies, if they are not installed already:
+    * snapd
+    * Anbox Management Client (AMC)
+    * LXD
+
+        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `latest/stable` track. If LXD is already installed but the version is older than 5.0, run ` snap refresh --channel=5.0/stable lxd` to update it.[/note]
+
+1. Install `anbox-cloud-appliance` snap from the `latest/stable` track.
+1. Configure the `apt` repositories for Anbox Cloud.
 
 <a name="initialise"></a>
 ## Initialise the appliance

--- a/tut/installing-appliance.md
+++ b/tut/installing-appliance.md
@@ -41,7 +41,7 @@ The Anbox Cloud Appliance requires a valid Ubuntu Pro subscription.
 
 Before installing the appliance, you must attach the machine on which you want to run the Anbox Cloud Appliance to your Ubuntu Pro subscription. To do so, run the following command, replacing *<pro_token>* with your Ubuntu Pro token:
 
-    sudo ua attach <pro_token>
+    sudo pro attach <pro_token>
 
 <a name="enable-anbox-service"></a>
 ### 3. Enable the `anbox-cloud` service using the Ubuntu Pro client.
@@ -52,15 +52,15 @@ On your machine, run the following command to install the Anbox Cloud Appliance 
 
 Running this command does the following:
 
-1. Install the following tools and dependencies, if they are not installed already:
+1. Installs the following tools and dependencies, if they are not installed already:
     * snapd
     * Anbox Management Client (AMC)
     * LXD
 
-        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `latest/stable` track. If LXD is already installed but the version is older than 5.0, run ` snap refresh --channel=5.0/stable lxd` to update it.[/note]
+        [note type="information" status="Important"] The Anbox Cloud Appliance requires LXD >= 5.0 and hence LXD is installed from the `latest/stable` track. If LXD is already installed but the version is older than 5.0, run `snap refresh --channel=5.0/stable lxd` to update it.[/note]
 
-1. Install `anbox-cloud-appliance` snap from the `latest/stable` track.
-1. Configure the `apt` repositories for Anbox Cloud.
+1. Installs `anbox-cloud-appliance` snap from the `latest/stable` track.
+1. Configures the `apt` repositories for Anbox Cloud.
 
 <a name="initialise"></a>
 ## Initialise the appliance


### PR DESCRIPTION
Update the appliance topic to replace separate steps of installing AMC, LXD and the appliance snap with steps to enable the `anbox-cloud` service through Ubuntu Pro client.

This change should not go out until September (1.19.1?) when the pro client changes will be rolled out.