### PR TITLE
Replace "AMS instances" and "Anbox Cloud instance"

### DIFF
--- a/exp/addons.md
+++ b/exp/addons.md
@@ -1,4 +1,4 @@
-Addons provide a way to extend and customise images in Anbox Cloud. Once you have created addons, you can create [hooks](https://discourse.ubuntu.com/t/28555) for them that are triggered based on events in the life cycle of an Anbox Cloud instance. You can create addons independently and later attach it to individual applications.
+Addons provide a way to extend and customise images in Anbox Cloud. Once you have created addons, you can create [hooks](https://discourse.ubuntu.com/t/28555) for them that are triggered based on events in the life cycle of an [instance](https://discourse.ubuntu.com/t/17763). You can create addons independently and later attach it to individual applications.
 
 To create or update an addon, you need a specific file structure for the directory containing your addon files. In the directory where you created your addon files, also create the following:
 

--- a/exp/addons.md
+++ b/exp/addons.md
@@ -1,4 +1,4 @@
-Addons provide a way to extend and customise images in Anbox Cloud. Once you have created addons, you can create [hooks](https://discourse.ubuntu.com/t/28555) for them that are triggered based on events in the life cycle of an [instance](https://discourse.ubuntu.com/t/17763). You can create addons independently and later attach it to individual applications.
+Addons provide a way to extend and customise images in Anbox Cloud. Once you have created addons, you can create [hooks](https://discourse.ubuntu.com/t/28555) for them that are triggered based on events in the life cycle of an [instance](https://discourse.ubuntu.com/t/26204#instance). You can create addons independently and later attach it to individual applications.
 
 To create or update an addon, you need a specific file structure for the directory containing your addon files. In the directory where you created your addon files, also create the following:
 

--- a/exp/anbox-cloud.md
+++ b/exp/anbox-cloud.md
@@ -51,7 +51,7 @@ Inside each Anbox subcluster, the following components are present:
 
 * **Anbox Management Service (AMS)** - AMS is the management tool for Anbox Cloud. It handles all aspects of the application and instance life cycle, including application and image update, while ensuring high density, performance, and fast startup times.
 
-  Users can connect to AMS via CLI or HTTP API calls on port 8444. AMS is installed as a snap on each of the control nodes and interacts with Anbox Cloud instances, requesting and releasing resources as per demand.
+  Users can connect to AMS via CLI or HTTP API calls on port 8444. AMS is installed as a snap on each of the control nodes and interacts with the instances, requesting and releasing resources as per demand.
 
 * **Anbox Management Client (AMC)**  - You can choose to install AMC on other machines to [control AMS remotely](https://discourse.ubuntu.com/t/how-to-control-ams-remotely/17774), but it is generally installed together with AMS. A developer or system administrator will manage AMS through the command line interface (AMC) or through custom-built tools interacting with the AMS HTTP API.
 
@@ -63,7 +63,7 @@ Each Anbox subcluster also has a number of LXD worker nodes that form a LXD clus
 
 * **LXD** - The LXD daemon spawns a number of LXD instances containing Anbox-related configuration. These instances provide an Ubuntu environment that uses the hardware of the LXD worker node, including CPUs, disks, networks, and if available, GPUs. Each LXD instance runs exactly one Android instance that the end user can access/stream.
 
-    [note type="information" status="Note"] The term LXD instance means that they are LXD containers or virtual machines that contain configuration related to Anbox Cloud. Within the context of Anbox Cloud, the term Anbox Cloud instances/images is synonymous with LXD instances/LXD images in the sense that they are LXD instances/images containing specific configuration related to Anbox Cloud.[/note]
+    [note type="information" status="Note"] The term LXD instance means that they are LXD containers or virtual machines that contain configuration related to Anbox Cloud. Within the context of Anbox Cloud, the term Anbox Cloud images is used interchangeably with LXD images in the sense that they are LXD images containing specific configuration related to Anbox Cloud.[/note]
 
 * **AMS node controller** – The AMS node controller puts the appropriate firewall rules in place when an instance is started or stopped to control ingress and egress traffic.
 
@@ -80,7 +80,7 @@ The diagram below depicts the streaming stack along with the core stack and user
 
 When the streaming stack is in use, each Anbox subcluster has the following additional components:
 
-* **TURN/STUN servers** - Servers that find the most optimal network path between a client and the Anbox Cloud instance running its application. The streaming stack provides secure STUN and TURN servers, but you can use public ones as well.
+* **TURN/STUN servers** - Servers that find the most optimal network path between a client and the application running on Anbox Cloud. The streaming stack provides secure STUN and TURN servers, but you can use public ones as well.
 
 * **Stream agent** - Serves as an entry point that the gateway can connect to to talk to the AMS of the Anbox subcluster.
 

--- a/exp/anbox-cloud.md
+++ b/exp/anbox-cloud.md
@@ -100,7 +100,7 @@ Anbox Cloud includes LXD for hosting and managing the Ubuntu instances that run 
 
 LXD is installed through the [`ams-lxd` charm](https://charmhub.io/ams-lxd), which adds some Anbox-specific configuration to LXD. AMS configures LXD automatically and fully manages it, which means that in most scenarios, you do not need to worry about LXD at all.
 
-If you want to monitor LXD, you can always run `lxc list` to display the existing instances. For the full deployment, LXD hosts the AMS instances. If you run the Anbox Cloud Appliance, LXD hosts instances for the different Juju machines that Anbox Cloud requires:
+If you want to monitor LXD, you can always run `lxc list` to display the existing instances. For the full deployment, LXD hosts the instances created by AMS. If you run the Anbox Cloud Appliance, LXD hosts instances for the different Juju machines that Anbox Cloud requires:
 
 ```
 +--------------------------+---------+------------------------+------+-----------+-----------+----------+
@@ -129,7 +129,7 @@ While a loop file is easy to set up, it is much slower than a block device. Ther
 
 If you are doing a full deployment, configure the storage before starting the deployment. See the *Customise storage* section in [How to deploy Anbox Cloud with Juju](https://discourse.ubuntu.com/t/install-with-juju/17744#customise-storage) or [How to deploy Anbox Cloud on bare metal](https://discourse.ubuntu.com/t/deploy-anbox-cloud-on-bare-metal/26378#customise-storage) for instructions. If you skip the configuration, Anbox Cloud sets up a loop-file with an automatically calculated size, which is not recommended.
 
-If you are using the Anbox Cloud Appliance, you are prompted during the initialisation process to specify the storage location, and, if you choose a loop file, its size. When choosing a size, keep in mind that the loop file cannot be larger than the root disk, and that it will cause the disk to fill up as the loop file grows to its maximum size over time. The created storage pool is used to store all Anbox Cloud content, thus both the Juju and AMS instances.
+If you are using the Anbox Cloud Appliance, you are prompted during the initialisation process to specify the storage location, and, if you choose a loop file, its size. When choosing a size, keep in mind that the loop file cannot be larger than the root disk, and that it will cause the disk to fill up as the loop file grows to its maximum size over time. The created storage pool is used to store all Anbox Cloud content, including the instances created by Juju.
 
 <a name="juju-bundles"></a>
 ## Juju bundles

--- a/exp/anbox-cloud.md
+++ b/exp/anbox-cloud.md
@@ -1,6 +1,6 @@
 Anbox Cloud provides a rich software stack that enables you to run Android applications in the cloud for different use cases, including high-performance streaming of graphics to desktop and mobile client devices.
 
-Anbox Cloud maintains a single Android system per instance, providing higher density and better performance per host while ensuring security and isolation of each instance. Depending on the target platform, payload, and desired application performance (for example, frame rate), Anbox Cloud can run more than 100 instances on a single machine.
+Anbox Cloud maintains a single Android system per [instance](https://discourse.ubuntu.com/t/26204#instance), providing higher density and better performance per host while ensuring security and isolation of each instance. Depending on the target platform, payload, and desired application performance (for example, frame rate), Anbox Cloud can run more than 100 instances on a single machine.
 
 <a name="variants"></a>
 ## Variants

--- a/exp/instances.md
+++ b/exp/instances.md
@@ -22,7 +22,7 @@ Application instances are containers or virtual machines created when launching 
 
 Raw instances are containers or virtual machines created when launching an image. They run the full Android system, without any additional apps installed.
 
-## Life cycle of an Anbox Cloud instance
+## Life cycle of an instance
 
 ### Creating an instance
 
@@ -41,7 +41,7 @@ Launching an instance is successful only if all of the above steps succeed. If t
 
 ### Stopping an instance
 
-Anbox Cloud instances can be stopped because of the following scenarios:
+Instances can be stopped because of the following scenarios:
 
 - You stopped it.
 - You deleted it.

--- a/exp/landing.md
+++ b/exp/landing.md
@@ -6,7 +6,7 @@ Understand the underlying architecture of Anbox Cloud, its variants and how the 
 |  Guides | What they explain |
 |--|--|
 | [Anbox Cloud](https://discourse.ubuntu.com/t/17802) | Differences between Anbox Cloud and the Anbox Cloud Appliance, explanation about the components and architecture of the offering |
-| [AMS](https://discourse.ubuntu.com/t/24321)| The Anbox Management Service (AMS) and how it handles aspects of the application and life cycle of an Anbox cloud instance |
+| [AMS](https://discourse.ubuntu.com/t/24321)| The Anbox Management Service (AMS) and how it handles aspects of the application and life cycle of an instance |
 | [AAR](https://discourse.ubuntu.com/t/17761)| The Anbox Application Registry (AAR) and what it does|
 | [Application streaming](https://discourse.ubuntu.com/t/17769)| Architecture of the Streaming Stack and supported video codecs |
 | [Rendering architecture](https://discourse.ubuntu.com/t/35129)| Different rendering pipelines for supported GPUs |
@@ -17,7 +17,7 @@ Understand the different objects used in the product stack and how to use them t
 | Guides  | What they explain  |
 |--|--|
 | [Applications](https://discourse.ubuntu.com/t/17760)| Application requirements and the application bootstrap process |
-| [Instances](https://discourse.ubuntu.com/t/17763)| About an Anbox Cloud instance and its life cycle |
+| [Instances](https://discourse.ubuntu.com/t/17763)| Learn about an instance and its life cycle |
 | [Platforms](https://discourse.ubuntu.com/t/configuration-for-supported-platforms/18733)| Configuring supported platforms |
 | [Clustering](https://discourse.ubuntu.com/t/17765)| Clustering and managing the load over multiple machines|
 | [Performance](https://discourse.ubuntu.com/t/29416) | Aspects that are relevant for tuning the performance of Anbox Cloud |

--- a/exp/performance.md
+++ b/exp/performance.md
@@ -5,9 +5,9 @@ To measure the performance based on different parameters, you should [run perfor
 The main areas for performance tuning are:
 
 - [Instance density](#instance-density)
-- [CPU access for an Anbox Cloud instance](#instance-cpu-access)
+- [CPU access for an instance](#instance-cpu-access)
 - [Hardware and network setup](#hardware-setup)
-- [Startup time for an Anbox Cloud instance](#startup-time)
+- [Startup time for an instance](#startup-time)
 - [Client devices](#client-devices)
 
 <a name="instance-density"></a>
@@ -22,7 +22,7 @@ In addition, check your applications and make sure they use the resources in a f
 Generally, applications should use the smallest suitable instance type. However, if you see an overall bad performance when running the application, using a more powerful instance type usually helps (even though it reduces the instance density). As an example, consider an application that runs on an Anbox Cloud deployment that does not have any GPUs installed. In this case, the rendering workload is put on the CPU instead of the GPU, and if the instance type of the application does not have a sufficient number of vCPU cores, the performance of the application is impacted. This can show, for example, in the virtual keyboard being really slow. By switching to a more powerful instance type, the instance density is reduced, but the performance of each application instance is increased.
 
 <a name="instance-cpu-access"></a>
-## CPU access for an Anbox Cloud instance
+## CPU access for an instance
 
 AMS has different modes to grant CPU access to an instance. The `cpu.limit_mode` configuration option can be used to change the mode. The possible modes are:
 
@@ -49,7 +49,7 @@ The overall performance depends not only on the hardware used for the actual Anb
 Also make sure that there is a stable network connection between the nodes of your cluster, to decrease the latency between nodes.
 
 <a name="startup-time"></a>
-## Startup time for an Anbox Cloud instance
+## Startup time for an instance
 
 A very noticeable performance issue is a long wait time when starting an application.
 

--- a/exp/platforms.md
+++ b/exp/platforms.md
@@ -1,6 +1,6 @@
 Anbox Cloud currently supports the `swrast`, `null`, `webrtc` platforms. This guide covers the display settings configuration for these platforms.
 
-To instruct an Anbox Cloud instance to use a platform, include the `--platform` (or `-p`) flag when launching the instance:
+To instruct an instance to use a platform, include the `--platform` (or `-p`) flag when launching the instance:
 
     amc launch -p webrtc <application>
 
@@ -23,7 +23,7 @@ If you want to change the display settings of the Android container, you need to
 
     <Display width>,<Display height>,<FPS>,<Display density>
 
-The first two fields which imply display width and display height respectively are required, however the latter two are optional. When launching an Anbox Cloud instance, mention the display settings via user data:
+The first two fields which imply display width and display height respectively are required, however the latter two are optional. When launching an instance, mention the display settings via user data:
 
     amc launch --userdata="960,720,30,120" -p swrast <application>
 

--- a/exp/platforms.md
+++ b/exp/platforms.md
@@ -1,6 +1,6 @@
 Anbox Cloud currently supports the `swrast`, `null`, `webrtc` platforms. This guide covers the display settings configuration for these platforms.
 
-To instruct an instance to use a platform, include the `--platform` (or `-p`) flag when launching the instance:
+To instruct an [instance](https://discourse.ubuntu.com/t/26204#instance) to use a platform, include the `--platform` (or `-p`) flag when launching the instance:
 
     amc launch -p webrtc <application>
 

--- a/howto/addons/landing.md
+++ b/howto/addons/landing.md
@@ -1,4 +1,4 @@
-Addons can be used to customise the images used for the Anbox Cloud instances. See [Addons](https://discourse.ubuntu.com/t/38727) and [Addon manifest](https://discourse.ubuntu.com/t/25293) to learn about addons in detail.
+In Anbox Cloud, addons can be used to customise the images used for the instances. See [Addons](https://discourse.ubuntu.com/t/38727) and [Addon manifest](https://discourse.ubuntu.com/t/25293) to learn about addons in detail.
 
 If this is your first time creating an addon, follow the [Create an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284) tutorial to learn how to write a simple addon.
 

--- a/howto/addons/landing.md
+++ b/howto/addons/landing.md
@@ -1,4 +1,4 @@
-In Anbox Cloud, addons can be used to customise the images used for the instances. See [Addons](https://discourse.ubuntu.com/t/38727) and [Addon manifest](https://discourse.ubuntu.com/t/25293) to learn about addons in detail.
+In Anbox Cloud, addons can be used to customise the images used for the [instances](https://discourse.ubuntu.com/t/26204#instance). See [Addons](https://discourse.ubuntu.com/t/38727) and [Addon manifest](https://discourse.ubuntu.com/t/25293) to learn about addons in detail.
 
 If this is your first time creating an addon, follow the [Create an addon](https://discourse.ubuntu.com/t/creating-an-addon/25284) tutorial to learn how to write a simple addon.
 

--- a/howto/addons/migrate.md
+++ b/howto/addons/migrate.md
@@ -5,7 +5,7 @@ Starting with Anbox Cloud 1.12, use the following new hooks instead of the depre
 * Use `post-start` instead of `prepare`
 * Use `post-stop` instead of `backup`
 
-The new hooks run for **all** types of Anbox Cloud instances (containers and virtual machines). To execute a hook only for a regular or a base instance, use the `INSTANCE_TYPE` environment variable. This variable is set to either `base` or `regular`.
+The new hooks run for **all** types of instances (containers and virtual machines). To execute a hook only for a regular or a base instance, use the `INSTANCE_TYPE` environment variable. This variable is set to either `base` or `regular`.
 
 For example, if you want to execute a hook only when your application is bootstrapped, you can do the following:
 ```bash

--- a/howto/anbox/develop-platform.md
+++ b/howto/anbox/develop-platform.md
@@ -29,7 +29,7 @@ The build process creates a `platform_minimal.so` module in the `build` director
 
 ## Install the example platform
 
-[AMS](https://discourse.ubuntu.com/t/about-ams/24321) allows launching Anbox Cloud instances in a special [development mode](https://discourse.ubuntu.com/t/17763#dev-mode), which is helpful when developing, for example, addons or platforms. In development mode, the Anbox runtime does not terminate the instance when it detects failures or other problems.
+[AMS](https://discourse.ubuntu.com/t/about-ams/24321) allows launching instances in a special [development mode](https://discourse.ubuntu.com/t/17763#dev-mode), which is helpful when developing, for example, addons or platforms. In development mode, the Anbox runtime does not terminate the instance when it detects failures or other problems.
 
 To try out the `minimal` platform, complete the following steps:
 

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -1,4 +1,4 @@
-Anbox Cloud enables you to run automated tests for Android applications at scale. In the following example, we make use of [Appium](http://appium.io/) to interact with an instance running on Anbox Cloud and automate UI testing for Android applications.
+Anbox Cloud enables you to run automated tests for Android applications at scale. In the following example, we make use of [Appium](http://appium.io/) to interact with an [instance](https://discourse.ubuntu.com/t/26204#instance) running on Anbox Cloud and automate UI testing for Android applications.
 
 ## Setup Anbox Cloud for Appium
 

--- a/howto/application/test.md
+++ b/howto/application/test.md
@@ -63,7 +63,7 @@ Appium uses ADB as located in the Android SDK to establish a connection between 
 
 ## Execute Tests with Appium
 
-Once the connection is established between the Anbox Cloud instance and your development machine through ADB, you can launch the Appium desktop application to execute test cases.
+Once the connection is established between the instance and your development machine through ADB, you can launch the Appium desktop application to execute test cases.
 
 ### Manually provided APK
 

--- a/howto/install-appliance/aws.md
+++ b/howto/install-appliance/aws.md
@@ -96,7 +96,7 @@ For reference, all required ports are documented [here](https://discourse.ubuntu
 
 ### 6. Add storage
 
-The Anbox Cloud instance requires sufficient storage to work correctly. For optimal performance, we recommend the following setup:
+The instance requires sufficient storage to work correctly. For optimal performance, we recommend the following setup:
 
 * A root disk with a minimum of 50 GB (required)
 * An additional EBS volume of at least 50 GB (strongly recommended)

--- a/howto/instance/landing.md
+++ b/howto/instance/landing.md
@@ -1,3 +1,3 @@
-The guides in this section describe how to work with Anbox Cloud instances.
+The guides in this section describe how to work with instances in Anbox Cloud.
 
 See [About instances](https://discourse.ubuntu.com/t/17763) for an introduction to how instances are used in Anbox Cloud.

--- a/howto/instance/start.md
+++ b/howto/instance/start.md
@@ -5,7 +5,7 @@ When an instance is either initialised with the `amc init` (see [Create an insta
 `<instance_id>` is the ID of the instance that you want to start.
 
 [note type="information" status="Important"]
-Do not use the `lxc` command to manage an instance. Always use the `amc` command instead. Anbox Cloud instances have their own life cycle and using the `lxc` command to manage an instance can cause the instance to be out of sync.
+Do not use the `lxc` command to manage an instance. Always use the `amc` command instead. In Anbox Cloud, instances have their own life cycle and using the `lxc` command to manage an instance can cause the instance to be out of sync.
 [/note]
 
 By default, the `amc start` command waits 5 minutes for an instance to run before the operation times out. When starting an instance, you can specify a custom wait time with the `--timeout` option.

--- a/howto/instance/stop.md
+++ b/howto/instance/stop.md
@@ -5,7 +5,7 @@ A running instance can be stopped using the `amc stop` command:
 `<instance_id>` is the ID of the instance that you want to stop.
 
 [note type="information" status="Important"]
-Do not use the `lxc` command to manage an instance. Always use the `amc` command instead. Anbox Cloud instances have their own life cycle and using the `lxc` command to manage an instance can cause the instance to be out of sync.
+Do not use the `lxc` command to manage an instance. Always use the `amc` command instead. In Anbox Cloud, instances have their own life cycle and using the `lxc` command to manage an instance can cause the instance to be out of sync.
 [/note]
 
 By default, the `amc stop` command waits 5 minutes for an instance to stop before the operation times out. If you want to specify a custom wait time, you can do so by using the `--timeout` option in the `amc stop` command.

--- a/howto/monitor/collect-metrics.md
+++ b/howto/monitor/collect-metrics.md
@@ -2,7 +2,7 @@ This example implementation provides a starting point for a monitoring stack tha
 
 [note type="information" status="Important"]This reference implementation is provided for demonstration purposes only. It does not cover all aspects that you should consider for a production-level solution (for example, high availability). It cannot be used with the Anbox Cloud Appliance.[/note]
 
-In this setup, every LXD cluster node runs a Telegraf instance that gathers the machine metrics. All Anbox Cloud instances that exist on the node also report their metrics to the Telegraf instance.
+In this setup, every LXD cluster node runs a Telegraf instance that gathers the machine metrics. All instances that exist on the node also report their metrics to the Telegraf instance.
 
 Prometheus gathers the metrics provided by the different sources (the Telegraf instances, AMS, Anbox Stream Gateway and NATS) and stores them in its time series database. You can then access, query and visualise the full metrics data through Grafana.
 

--- a/howto/monitor/collect-metrics.md
+++ b/howto/monitor/collect-metrics.md
@@ -2,7 +2,7 @@ This example implementation provides a starting point for a monitoring stack tha
 
 [note type="information" status="Important"]This reference implementation is provided for demonstration purposes only. It does not cover all aspects that you should consider for a production-level solution (for example, high availability). It cannot be used with the Anbox Cloud Appliance.[/note]
 
-In this setup, every LXD cluster node runs a Telegraf instance that gathers the machine metrics. All instances that exist on the node also report their metrics to the Telegraf instance.
+In this setup, every LXD cluster node runs a Telegraf instance that gathers the machine metrics. All [instances](https://discourse.ubuntu.com/t/26204#instance) that exist on the node also report their metrics to the Telegraf instance.
 
 Prometheus gathers the metrics provided by the different sources (the Telegraf instances, AMS, Anbox Stream Gateway and NATS) and stores them in its time series database. You can then access, query and visualise the full metrics data through Grafana.
 

--- a/howto/stream/oob-data.md
+++ b/howto/stream/oob-data.md
@@ -5,7 +5,7 @@ Anbox Cloud provides two versions of this OOB data exchange:
 * [Version 2](#oob-v2) provides a full-duplex bidirectional data transmission mode in which data can flow in both directions at the same time.
 
   Use this version if you start your implementation now. If you already have an existing implementation, you should plan to update it to use version 2.
-* [Version 1](#oob-v1) enables Android application developers to trigger an action from an Android application running in an instance and forward it to a WebRTC client through the Anbox WebRTC platform. When Anbox receives the action, as one peer of the WebRTC platform, the action is propagated from Anbox to the remote peer (the WebRTC client) through a WebRTC data channel. The client can then react to the action received from the remote peer and respond accordingly on the UI.
+* [Version 1](#oob-v1) enables Android application developers to trigger an action from an Android application running in an [instance](https://discourse.ubuntu.com/t/26204#instance) and forward it to a WebRTC client through the Anbox WebRTC platform. When Anbox receives the action, as one peer of the WebRTC platform, the action is propagated from Anbox to the remote peer (the WebRTC client) through a WebRTC data channel. The client can then react to the action received from the remote peer and respond accordingly on the UI.
 
   This version supports only half-duplex data transmission. It allows sending data from an Android application to a WebRTC client through the Anbox WebRTC platform, but it is not possible to receive data from the WebRTC client to an Android application.
 

--- a/howto/stream/oob-data.md
+++ b/howto/stream/oob-data.md
@@ -75,7 +75,7 @@ At the same time, a number of Unix domain sockets are created under the `/run/us
 - Receive data sent from a WebRTC client over the data channel and forward it to an Android application.
 - Receive data sent from an Android application and forward it to a WebRTC client over the data channel.
 
-A trivial example to simulate the data transmission between an Anbox Cloud instance and a WebRTC client is using the [`socat`](https://manpages.ubuntu.com/manpages/bionic/man1/socat.1.html) command to connect the Unix domain socket and perform bidirectional asynchronous data sending and receiving:
+A trivial example to simulate the data transmission between an instance and a WebRTC client is using the [`socat`](https://manpages.ubuntu.com/manpages/bionic/man1/socat.1.html) command to connect the Unix domain socket and perform bidirectional asynchronous data sending and receiving:
 
 1. Connect the Unix domain socket:
 
@@ -114,7 +114,7 @@ To build up the communication bridge between an Android application and the Anbo
  * Connecting to one specific data channel via the Unix domain socket exposed by the Anbox WebRTC platform
  * Passing the connected socket as a file descriptor to the Android application
 
-The `anbox-webrtc-data-proxy` system daemon runs in the Anbox Cloud instance and registers an Android system service named `org.anbox.webrtc.IDataProxyService`. This service allows Android developers to easily make use of binder interprocess communication (IPC) for data communication between an Android application and the Anbox WebRTC platform through a file descriptor.
+The `anbox-webrtc-data-proxy` system daemon runs in the instance and registers an Android system service named `org.anbox.webrtc.IDataProxyService`. This service allows Android developers to easily make use of binder interprocess communication (IPC) for data communication between an Android application and the Anbox WebRTC platform through a file descriptor.
 
 [note type="information" status="Note"]To interact with the `org.anbox.webrtc.IDataProxyService` system service, the Android application must be [installed as a system app](https://discourse.ubuntu.com/t/how-to-install-an-apk-as-a-system-app/27086). [/note]
 
@@ -363,7 +363,7 @@ in JavaScript, C or C++ by using the Anbox Streaming SDK.
 
 For a web-based application, you can use the JavaScript SDK which you can find under
 [Anbox Cloud SDKs](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#streaming-sdk). To receive the data sent from the Android application
-running in the Anbox Cloud instance, implement the `messageReceived` callback
+running in the instance, implement the `messageReceived` callback
 of the `AnboxStream` object:
 
 ```

--- a/howto/troubleshoot/landing.md
+++ b/howto/troubleshoot/landing.md
@@ -21,7 +21,7 @@ If you have the [`juju-crashdump` plugin](https://github.com/juju/juju-crashdump
 
 A Juju crash dump may include the following debugging information:
 * Additional information provided by the Anbox Cloud charms
-* Information about any Anbox Cloud instances that crashed
+* Information about any instances that crashed
 
 Use the following command to generate a crash dump:
 
@@ -41,7 +41,7 @@ This is the recommended option to provide debugging information when you report 
 
 *Applies to: Anbox Cloud, Anbox Cloud Appliance since 1.16.0*
 
-Anbox Cloud instances come preinstalled with the `anbox-bug-report` utility, which
+In Anbox Cloud, instances come preinstalled with the `anbox-bug-report` utility, which
 collects the log files and other relevant information for a specific instance.
 To generate the report and save it to a local file, use `amc exec` on a running
 instance:

--- a/ref/anbox-https-api.md
+++ b/ref/anbox-https-api.md
@@ -1,4 +1,4 @@
-Anbox Cloud provides an HTTP API endpoint through a Unix socket at `/run/users/1000/anbox/api.socket` inside every instance. The API allows controlling certain aspects of the Anbox runtime and the Android container.
+Anbox Cloud provides an HTTP API endpoint through a Unix socket at `/run/users/1000/anbox/api.socket` inside every [instance](https://discourse.ubuntu.com/t/26204#instance). The API allows controlling certain aspects of the Anbox runtime and the Android container.
 
 ## Accessing the API endpoint
 

--- a/ref/anbox-https-api.md
+++ b/ref/anbox-https-api.md
@@ -489,5 +489,5 @@ The available configuration items depend on the platform being used by Anbox and
 
 Platform | Field name       | Available since   | JSON type | Access | Description        |
 ---------|------------------|-------------------|-----------|--------|--------------------|
-`webrtc` | `rtc_log`         | 1.15 | Boolean   | read/write | Enable/disable [RTC event logging](https://webrtc.googlesource.com/src/+/lkgr/logging/g3doc/rtc_event_log.md). Logs are written to `/var/lib/anbox/traces/rtc_log.*` inside the Anbox Cloud instance. |
+`webrtc` | `rtc_log`         | 1.15 | Boolean   | read/write | Enable/disable [RTC event logging](https://webrtc.googlesource.com/src/+/lkgr/logging/g3doc/rtc_event_log.md). Logs are written to `/var/lib/anbox/traces/rtc_log.*` inside the instance. |
 `webrtc` | `stream_active`   | 1.15 | Boolean   | read | `true` if a client is actively streaming, `false` if no client is connected. |

--- a/ref/application-manifest.md
+++ b/ref/application-manifest.md
@@ -26,7 +26,7 @@ Name          | Value type | Description |
 <a name="instance-type"></a>
 ## Instance type
 
-Similar to other clouds, Anbox Cloud describes the amount of resources that are available to a single instance with an *instance type*. An instance type is a name that is mapped to a set of resources. This allows to have an easy abstraction when referring to resource requirements of Anbox Cloud instances or particular applications.
+Similar to other clouds, Anbox Cloud describes the amount of resources that are available to a single instance with an *instance type*. An instance type is a name that is mapped to a set of resources. This allows to have an easy abstraction when referring to resource requirements of instances or particular applications.
 
 Anbox Cloud offers the following instance types:
 
@@ -111,7 +111,7 @@ Supplying `['*']` to the `allowed-packages` when the watchdog is enabled allows 
 <a name="services"></a>
 ## Services
 
-An Anbox Cloud instance launched from the installed application can expose `services` you want to make accessible from outside the instance. You must define the following properties for each service:
+An instance launched from the installed application can expose `services` you want to make accessible from outside the instance. You must define the following properties for each service:
 
 Name           | Value type | Description
 ---------------|------------|-------------------------

--- a/ref/application-manifest.md
+++ b/ref/application-manifest.md
@@ -6,7 +6,7 @@ Name          | Value type | Description |
 --------------|------------|-------------------------|
 `name`          | string     | Verbose name of the application. The following special characters are not allowed: `< > : " / \ \| ? *`, as well as space |
 `version`       | string     | Version to encode with the application. Maximum length is 50 characters. |
-`instance-type` | string     | Instance type that all instances of Anbox Cloud created for the application will use. [Jump to details](#instance-type) |
+`instance-type` | string     | Instance type that all [instances](https://discourse.ubuntu.com/t/26204#instance) created for the application will use. [Jump to details](#instance-type) |
 `required-permissions` | array of strings | List of permissions to automatically grant to the application. See [Android Permissions](https://developer.android.com/guide/topics/permissions/overview) for a list of available permissions. If `[*]` was given, all required runtime permissions for the application will be granted on application installation. |
 `image` (optional) | string     | Name or ID of an image to be used for the application. The default image is used if empty. [Jump to details](#image) |
 `addons` (optional) | array      | List of addons to be installed during the application bootstrap process. |

--- a/ref/glossary.md
+++ b/ref/glossary.md
@@ -18,7 +18,6 @@
 - [Anbox Cloud Appliance](#anbox-cloud-appliance)
 - [Anbox Cloud cluster](#anbox-cloud-cluster)
 - [Anbox Cloud subcluster](#anbox-cloud-subcluster)
-- [Anbox Cloud instance](#anbox-instance)
 - [Anbox Management Client](#amc)
 - [Anbox Management Service](#ams)
 - [Anbox Platform SDK](#anbox-platform-sdk)
@@ -45,6 +44,7 @@
 - [High availability](#ha)
 - [Hook](#hook)
 - [Image](#image)
+- [Instance](#instance)
 - [Instance type](#instance-type)
 - [Juju](#juju)
 - [LXD](#lxd)
@@ -150,13 +150,6 @@ A deployment of the Anbox Cloud, either just the core stack or the core stack al
 
 The group of components that is made up of LXD, AMS node controller, and the [control node](#control-node) hosting the AMS, AMC, and etcd.
 
-<a name="anbox-instance"></a>
-### Anbox Cloud instance
-
-One of the main objects of Anbox Cloud. Every time you launch an application or an image, Anbox Cloud creates an instance for it. Every instance provides a full Android system. Within the context of Anbox Cloud, the term Anbox Cloud instances/images is synonymous with LXD instances/LXD images in the sense that they are LXD instances/images containing specific configuration related to Anbox Cloud.
-
-See https://discourse.ubuntu.com/t/17763.
-
 <a name="amc"></a>
 ### Anbox Management Client (AMC)
 
@@ -181,7 +174,7 @@ See [Anbox Platform SDK](https://discourse.ubuntu.com/t/anbox-cloud-sdks/17844#a
 <a name="anbox-shell"></a>
 ### Anbox shell
 
-A command-line tool (`anbox-shell`) that provides an ADB shell with root permissions granted, which you can use to access the Android system in the Anbox Cloud instance.
+A command-line tool (`anbox-shell`) that provides an ADB shell with root permissions granted, which you can use to access the Android system in the instance.
 
 See [Access an instance with AMC](https://discourse.ubuntu.com/t/17772#amc).
 
@@ -310,21 +303,28 @@ See https://discourse.ubuntu.com/t/enable-high-availability/17754.
 <a name="hook"></a>
 ### Hook
 
-Code that is invoked at different points in time in the life cycle of an Anbox Cloud instance. Hooks are part of addons or applications.
+Code that is invoked at different points in time in the life cycle of an instance. Hooks are part of addons or applications.
 
 See [Hooks](https://discourse.ubuntu.com/t/hooks/28555).
 
 <a name="image"></a>
 ### Image
 
-The base for an Anbox Cloud instance, which contains all necessary components like Anbox or the Android root file system. Anbox Cloud provides images based on different Android and Ubuntu versions and different architectures.
+The base for an instance, which contains all necessary components like Anbox or the Android root file system. Anbox Cloud provides images based on different Android and Ubuntu versions and different architectures.
 
 See https://discourse.ubuntu.com/t/manage-images/17758 and https://discourse.ubuntu.com/t/provided-images/24185.
+
+<a name="instance"></a>
+### Instance
+
+One of the main objects of Anbox Cloud. Every time you launch an application or an image, Anbox Cloud creates an instance for it. Every instance provides a full Android system. Within the context of Anbox Cloud, the term Anbox Cloud images is used interchangeably with LXD images in the sense that they are LXD images containing specific configuration related to Anbox Cloud.
+
+See https://discourse.ubuntu.com/t/17763.
 
 <a name="instance-type"></a>
 ### Instance type
 
-An abstraction for a set of resources that is available to an Anbox Cloud instance.
+An abstraction for a set of resources that is available to an instance.
 
 See https://discourse.ubuntu.com/t/application-manifest/24197#instance-type.
 

--- a/ref/glossary.md
+++ b/ref/glossary.md
@@ -317,7 +317,7 @@ See https://discourse.ubuntu.com/t/manage-images/17758 and https://discourse.ubu
 <a name="instance"></a>
 ### Instance
 
-One of the main objects of Anbox Cloud. Every time you launch an application or an image, Anbox Cloud creates an instance for it. Every instance provides a full Android system. Within the context of Anbox Cloud, the term Anbox Cloud images is used interchangeably with LXD images in the sense that they are LXD images containing specific configuration related to Anbox Cloud.
+An instance is a container or a virtual machine used to launch an application or an image. Every time you launch an application or an image, Anbox Cloud creates an instance for it. Every instance provides a full Android system.
 
 See https://discourse.ubuntu.com/t/17763.
 

--- a/ref/hooks.md
+++ b/ref/hooks.md
@@ -1,4 +1,4 @@
-Hooks are scripts that automatically trigger actions based on an event performed in the life cycle of an [instance](https://discourse.ubuntu.com/t/17763). A hook can be any executable file that is placed in the `hooks` directory of an addon or an application folder.
+Hooks are scripts that automatically trigger actions based on an event performed in the life cycle of an [instance](https://discourse.ubuntu.com/t/26204#instance). A hook can be any executable file that is placed in the `hooks` directory of an addon or an application folder.
 
 The hook name **must** be one of the following:
 

--- a/ref/hooks.md
+++ b/ref/hooks.md
@@ -1,4 +1,4 @@
-Hooks are scripts that automatically trigger actions based on an event performed in the life cycle of an Anbox Cloud instance. A hook can be any executable file that is placed in the `hooks` directory of an addon or an application folder.
+Hooks are scripts that automatically trigger actions based on an event performed in the life cycle of an [instance](https://discourse.ubuntu.com/t/17763). A hook can be any executable file that is placed in the `hooks` directory of an addon or an application folder.
 
 The hook name **must** be one of the following:
 

--- a/ref/license-information.md
+++ b/ref/license-information.md
@@ -1,4 +1,4 @@
-The copyright and license information of Anbox Cloud can be found within an Anbox Cloud instance at `/usr/share/doc/anbox/copyright`.
+The copyright and license information of Anbox Cloud can be found within the container or the virtual machine at `/usr/share/doc/anbox/copyright`.
 
 Anbox Cloud is built using multiple open source software components. This guide lists those components and where to find their license information.
 

--- a/ref/network-ports.md
+++ b/ref/network-ports.md
@@ -11,7 +11,7 @@ For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cl
 |-----------------------|-------------|-----------|--------------------|------------------------------|---------------------------------------|
 | AMS                   | 8444        | TCP       | no                 | yes                          | HTTPS API                             |
 | AMS                   | 20002       | TCP       | no                 | no                           | HTTPS Prometheus endpoint             |
-| AMS node controller   | 10000-11000 | UDP & TCP | yes                | no                           | Service ports for the Anbox Cloud instance|
+| AMS node controller   | 10000-11000 | UDP & TCP | yes                | no                           | Instance service ports                |
 | Anbox Cloud Dashboard | 5000        | TCP       | no                 | no                           | HTTPS website                         |
 | Anbox Stream Agent    | 443         | TCP       | no                 | yes                          | HTTPS API                             |
 | Anbox Stream Gateway  | 4000        | TCP       | no                 | yes                          | HTTPS API                             |
@@ -31,7 +31,7 @@ For the Anbox Cloud Appliance, ports are exposed only for accessing the Anbox Cl
 
 | Service             | Port(s)     | Protocol  | Required | Description                            |
 |---------------------|-------------|-----------|----------|----------------------------------------|
-| AMS node controller | 10000-11000 | UDP & TCP | no       | Service ports for the Anbox Cloud instance|
+| AMS node controller | 10000-11000 | UDP & TCP | no       | Instance service ports                 |
 | Coturn              | 5349        | UDP       | yes      | STUN/TURN                              |
 | Coturn              | 60000-60100 | UDP       | yes      | TURN relay ports                       |
 | Traefik             | 80          | TCP       | yes      | HTTP (redirects to HTTPS on port 443)  |

--- a/ref/requirements.md
+++ b/ref/requirements.md
@@ -102,7 +102,7 @@ ID | Architecture   | CPU cores | RAM  | Disk       | GPUs |  FUNCTION |
 0  | amd64 or arm64 | 2         | 2GB  | 100GB SSD  | no   |  Hosts the load balancer |
 1  | amd64 or arm64 | 4         | 8GB  | 100GB SSD  | no   |  Hosts the streaming stack control plane |
 2  | amd64 or arm64 | 4         | 8GB  | 100GB SSD  | no   |  Hosts the management layer of Anbox Cloud (for example, AMS) |
-3  | amd64 or arm64 | 8         | 16GB | 200GB NVMe | optional   |  LXD worker node that hosts the actual Anbox Cloud instances  |
+3  | amd64 or arm64 | 8         | 16GB | 200GB NVMe | optional   |  LXD worker node that hosts the actual containers or virtual machines  |
 
 To run the core version of Anbox Cloud without the streaming stack, we recommend the following setup:
 
@@ -110,7 +110,7 @@ ID | Architecture   | CPU cores | RAM  | Disk       | GPUs |  FUNCTION |
 ---|----------------|-----------|------|------------|------|------------|
 -  | amd64 or arm64 | 4         | 4GB  | 50GB SSD   | no   |  Hosts the  [Juju controller](https://discourse.juju.is/t/controllers/1111)  |
 0  | amd64 or arm64 | 4         | 8GB  | 100GB SSD  | no   |  Hosts the management layer of Anbox Cloud (for example, AMS)  |
-1  | amd64 or arm64 | 8         | 16GB | 200GB NVMe | optional   |  LXD worker node that hosts the actual Anbox Cloud instances  |
+1  | amd64 or arm64 | 8         | 16GB | 200GB NVMe | optional   |  LXD worker node that hosts the actual containers or virtual machines  |
 
 Some additional information:
 

--- a/ref/webrtc-streamer.md
+++ b/ref/webrtc-streamer.md
@@ -1,6 +1,6 @@
 Usually you wouldn't need to adjust the default WebRTC streamer configuration because it is optimised to provide a good balance between low latency and high quality. However, you can still fine-tune it to provide better results in certain situations.
 
-Place the WebRTC streamer configuration at `/var/lib/anbox/streamer.json` within the instance before the Anbox runtime starts. The configuration can be shipped as part of an [application](https://discourse.ubuntu.com/t/managing-applications/17760) or an [addon](https://discourse.ubuntu.com/t/managing-addons/17759).
+Place the WebRTC streamer configuration at `/var/lib/anbox/streamer.json` within the [instance](https://discourse.ubuntu.com/t/26204#instance) before the Anbox runtime starts. The configuration can be shipped as part of an [application](https://discourse.ubuntu.com/t/managing-applications/17760) or an [addon](https://discourse.ubuntu.com/t/managing-addons/17759).
 
 The configuration file uses the JSON format. It has the following structure:
 

--- a/ref/webrtc-streamer.md
+++ b/ref/webrtc-streamer.md
@@ -1,6 +1,6 @@
 Usually you wouldn't need to adjust the default WebRTC streamer configuration because it is optimised to provide a good balance between low latency and high quality. However, you can still fine-tune it to provide better results in certain situations.
 
-Place the WebRTC streamer configuration at `/var/lib/anbox/streamer.json` within the Anbox Cloud instance before the Anbox runtime starts. The configuration can be shipped as part of an [application](https://discourse.ubuntu.com/t/managing-applications/17760) or an [addon](https://discourse.ubuntu.com/t/managing-addons/17759).
+Place the WebRTC streamer configuration at `/var/lib/anbox/streamer.json` within the instance before the Anbox runtime starts. The configuration can be shipped as part of an [application](https://discourse.ubuntu.com/t/managing-applications/17760) or an [addon](https://discourse.ubuntu.com/t/managing-addons/17759).
 
 The configuration file uses the JSON format. It has the following structure:
 


### PR DESCRIPTION
Anbox Cloud instance(s) - This terminology should be avoided because in certain contexts, it could be a deployment of Anbox Cloud as opposed to an Anbox Cloud container or VM. Based on this decision taken during our discussions, the mentions of Anbox Cloud instance(s) are reworded to avoid ambiguity.

AMS instances - Need a decision on this terminology as these are much more context-based. [This](https://chat.canonical.com/canonical/pl/sf1gdefq5pr7dgjtxujd1sb9uh) is the Mattermost discussion thread.
Update: Reworded based on context as per discussions in SU and Mattermost.