### PR TITLE
Replace juju run-action with juju run

### DIFF
--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -266,6 +266,6 @@ To reboot the machine hosting LXD, run the following command:
 
 When the machine is back running, you must manually clear the status of the LXD units:
 
-    juju run-action --wait lxd/0 clear-notification
+    juju run --wait lxd/0 clear-notification
 
 Once done, the reboot operation is finished.

--- a/howto/install/deploy-juju.md
+++ b/howto/install/deploy-juju.md
@@ -266,6 +266,6 @@ To reboot the machine hosting LXD, run the following command:
 
 When the machine is back running, you must manually clear the status of the LXD units:
 
-    juju run --wait lxd/0 clear-notification
+    juju run --wait=5m lxd/0 clear-notification
 
 Once done, the reboot operation is finished.

--- a/howto/manage/web-dashboard.md
+++ b/howto/manage/web-dashboard.md
@@ -27,7 +27,7 @@ Before you can log into the dashboard, you must register your Ubuntu One account
 
 On a regular Anbox Cloud deployment, use the following Juju action to register an Ubuntu One account:
 
-    juju run anbox-cloud-dashboard/0 --wait register-account email=<Ubuntu One email address>
+    juju run anbox-cloud-dashboard/0 --wait=5m register-account email=<Ubuntu One email address>
 
 You will see output similar to the following:
 

--- a/howto/manage/web-dashboard.md
+++ b/howto/manage/web-dashboard.md
@@ -27,7 +27,7 @@ Before you can log into the dashboard, you must register your Ubuntu One account
 
 On a regular Anbox Cloud deployment, use the following Juju action to register an Ubuntu One account:
 
-    juju run-action anbox-cloud-dashboard/0 --wait register-account email=<Ubuntu One email address>
+    juju run anbox-cloud-dashboard/0 --wait register-account email=<Ubuntu One email address>
 
 You will see output similar to the following:
 

--- a/howto/monitor/collect-metrics.md
+++ b/howto/monitor/collect-metrics.md
@@ -50,7 +50,7 @@ Replace `<IP_address>` with the IP address of the machine on which you deployed 
 
 You must enter your user name and password to log in. The user name is `admin`. You can determine the password by running the following command:
 
-    juju run-action --wait grafana/0 get-admin-password
+    juju run --wait grafana/0 get-admin-password
 
 If you have deployed more than one Grafana unit, you might need to replace the `0` in `grafana/0` with the suitable unit ID. Check `juju status` if you are in doubt.
 

--- a/howto/monitor/collect-metrics.md
+++ b/howto/monitor/collect-metrics.md
@@ -50,7 +50,7 @@ Replace `<IP_address>` with the IP address of the machine on which you deployed 
 
 You must enter your user name and password to log in. The user name is `admin`. You can determine the password by running the following command:
 
-    juju run --wait grafana/0 get-admin-password
+    juju run --wait=5m grafana/0 get-admin-password
 
 If you have deployed more than one Grafana unit, you might need to replace the `0` in `grafana/0` with the suitable unit ID. Check `juju status` if you are in doubt.
 

--- a/ref/prometheus.md
+++ b/ref/prometheus.md
@@ -16,8 +16,8 @@ You can access the AMS metrics from any machine that is on the same network as y
 
 Replace `<AMS_server>` with the IP address of your AMS server, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju run --unit ams/0 -- unit-get private-address`
-* For the Anbox Cloud Appliance: `juju run -m appliance:anbox-cloud --unit ams/0 -- unit-get private-address`
+* For a full Anbox Cloud deployment: `juju run --wait=5m --unit ams/0 -- unit-get private-address`
+* For the Anbox Cloud Appliance: `juju run --wait=5m -m appliance:anbox-cloud --unit ams/0 -- unit-get private-address`
 
 Replace `<AMS_port>` with the port for the API endpoint, which you can determine by running one of the following commands:
 
@@ -151,8 +151,8 @@ You can access the Anbox Stream Gateway metrics from any machine that is on the 
 
 Replace `<gateway_server>` with the IP address of your Anbox Stream Gateway server, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju run --unit anbox-stream-gateway/0 -- unit-get private-address`
-* For the Anbox Cloud Appliance: `juju run -m appliance:anbox-cloud --unit anbox-stream-gateway/0 -- unit-get private-address`
+* For a full Anbox Cloud deployment: `juju run --unit anbox-stream-gateway/0 --wait=5m -- unit-get private-address`
+* For the Anbox Cloud Appliance: `juju run --wait=5m -m appliance:anbox-cloud --unit anbox-stream-gateway/0 -- unit-get private-address`
 
 Replace `<gateway_port>` with the port for the API endpoint, which you can determine by running one of the following commands:
 
@@ -242,8 +242,8 @@ You can access the LXD metrics through the following endpoint:
 
 Replace `<LXD_server>` with the IP address of your LXD server, which you can determine by running one of the following commands:
 
-* For a full Anbox Cloud deployment: `juju run --unit lxd/0 -- unit-get private-address`
-* For the Anbox Cloud Appliance: `juju run -m appliance:anbox-cloud --unit lxd/0 -- unit-get private-address`
+* For a full Anbox Cloud deployment: `juju run --wait=5m --unit lxd/0 -- unit-get private-address`
+* For the Anbox Cloud Appliance: `juju run --wait=5m -m appliance:anbox-cloud --unit lxd/0 -- unit-get private-address`
 
 The LXD metrics endpoint is on HTTPS, and therefore you must authenticate to access it. See [Create metrics certificate](https://documentation.ubuntu.com/lxd/en/latest/metrics/#add-a-metrics-certificate-to-lxd) in the LXD documentation for instructions on how to create a certificate.
 


### PR DESCRIPTION
Recommended juju version is 3 and `juju run-action` is not supported in version 3. Hence, replacing it with `juju run`.