### PR TITLE
Create command reference topics for AMC

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -60,6 +60,7 @@ Coturn
 CPUs
 crashdump
 Crashpad
+CSV
 CTS
 CUDA
 customisable

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -152,6 +152,7 @@ LTS
 LXC
 LXD
 MAAS
+macOS
 middleware
 Minetest
 mutex
@@ -190,6 +191,7 @@ PKI
 playout
 Plex
 PLI
+powershell
 pre
 preselected
 Quadro

--- a/index.md
+++ b/index.md
@@ -136,6 +136,7 @@ Thinking about using Anbox Cloud for your next project? [Get in touch!](https://
 | 3 | ref/component-versions | [Component versions](https://discourse.ubuntu.com/t/component-versions/21413)|
 | 2 | ref/requirements | [Requirements](https://discourse.ubuntu.com/t/installation-requirements/17734) |
 | 2 | ref/appliance-command-reference/landing | [Appliance command reference](https://discourse.ubuntu.com/t/39525)|
+| 2 | ref/amc-command-reference/landing | [AMC command reference](https://discourse.ubuntu.com/t/40797) |
 | 2 | ref/provided-images | [Provided images](https://discourse.ubuntu.com/t/provided-images/24185)|
 | 2 | ref/supported-rendering-resources | [Supported rendering resources](https://discourse.ubuntu.com/t/supported-rendering-resources/37322) |
 | 2 | ref/supported-codecs | [Supported codecs](https://discourse.ubuntu.com/t/37323)|
@@ -233,15 +234,37 @@ Thinking about using Anbox Cloud for your next project? [Get in touch!](https://
 |   | release-notes/1.7.3 | [Release notes-Anbox Cloud 1.7.3](https://discourse.ubuntu.com/t/18458)|
 |   | release-notes/1.7.2 | [Release notes-Anbox Cloud 1.7.2](https://discourse.ubuntu.com/t/18265)|
 |   | release-notes/1.7.1 | [Release notes-Anbox Cloud 1.7.1](https://discourse.ubuntu.com/t/17977)|
-|   | ref/command-reference/ams | [Command reference - ams](https://discourse.ubuntu.com/t/39517)|
-|   | ref/command-reference/cluster | [Command reference - cluster](https://discourse.ubuntu.com/t/39519)|
-|   | ref/command-reference/dashboard | [Command reference - dashboard](https://discourse.ubuntu.com/t/39520)|
-|   | ref/command-reference/destroy | [Command reference - destroy](https://discourse.ubuntu.com/t/39521)|
-|   | ref/command-reference/gateway | [Command reference - gateway](https://discourse.ubuntu.com/t/39522)|
-|   | ref/command-reference/help | [Command reference - help](https://discourse.ubuntu.com/t/39523)|
-|   | ref/command-reference/init | [Command reference - init](https://discourse.ubuntu.com/t/39524)|
-|   | ref/command-reference/status | [Command reference - status](https://discourse.ubuntu.com/t/39527)|
-|   | ref/command-reference/upgrade | [Command reference - upgrade](https://discourse.ubuntu.com/t/39528)|
+|   | ref/appliance-command-reference/ams | [Appliance command reference - ams](https://discourse.ubuntu.com/t/39517)|
+|   | ref/appliance-command-reference/cluster | [Appliance command reference - cluster](https://discourse.ubuntu.com/t/39519)|
+|   | ref/appliance-command-reference/dashboard | [Appliance command reference - dashboard](https://discourse.ubuntu.com/t/39520)|
+|   | ref/appliance-command-reference/destroy | [Appliance command reference - destroy](https://discourse.ubuntu.com/t/39521)|
+|   | ref/appliance-command-reference/gateway | [Appliance command reference - gateway](https://discourse.ubuntu.com/t/39522)|
+|   | ref/appliance-command-reference/help | [Appliance command reference - help](https://discourse.ubuntu.com/t/39523)|
+|   | ref/appliance-command-reference/init | [Appliance command reference - init](https://discourse.ubuntu.com/t/39524)|
+|   | ref/appliance-command-reference/status | [Appliance command reference - status](https://discourse.ubuntu.com/t/39527)|
+|   | ref/appliance-command-reference/upgrade | [Appliance command reference - upgrade](https://discourse.ubuntu.com/t/39528)|
+|   | ref/amc-command-reference/addon | [AMC command reference - addon](https://discourse.ubuntu.com/t/40775) |
+|   | ref/amc-command-reference/application | [AMC command reference - application](https://discourse.ubuntu.com/t/40776) |
+|   | ref/amc-command-reference/benchmark | [AMC command reference - benchmark](https://discourse.ubuntu.com/t/40777) |
+|   | ref/amc-command-reference/completion | [AMC command reference - completion](https://discourse.ubuntu.com/t/40778) |
+|   | ref/amc-command-reference/config | [AMC command reference - config](https://discourse.ubuntu.com/t/40779) |
+|   | ref/amc-command-reference/delete | [AMC command reference - delete](https://discourse.ubuntu.com/t/40780) |
+|   | ref/amc-command-reference/exec | [AMC command reference - exec](https://discourse.ubuntu.com/t/40781) |
+|   | ref/amc-command-reference/help | [AMC command reference - help](https://discourse.ubuntu.com/t/40782) |
+|   | ref/amc-command-reference/image | [AMC command reference - image](https://discourse.ubuntu.com/t/40783) |
+|   | ref/amc-command-reference/info | [AMC command reference - info](https://discourse.ubuntu.com/t/40784) |
+|   | ref/amc-command-reference/init | [AMC command reference - init](https://discourse.ubuntu.com/t/40785) |
+|   | ref/amc-command-reference/launch | [AMC command reference - launch](https://discourse.ubuntu.com/t/40786) |
+|   | ref/amc-command-reference/list | [AMC command reference - list](https://discourse.ubuntu.com/t/40787) |
+|   | ref/amc-command-reference/logs | [AMC command reference - logs](https://discourse.ubuntu.com/t/40788) |
+|   | ref/amc-command-reference/node | [AMC command reference - node](https://discourse.ubuntu.com/t/40789) |
+|   | ref/amc-command-reference/remote | [AMC command reference - remote](https://discourse.ubuntu.com/t/40790) |
+|   | ref/amc-command-reference/shell | [AMC command reference - shell](https://discourse.ubuntu.com/t/40791) |
+|   | ref/amc-command-reference/show-log | [AMC command reference - show-log](https://discourse.ubuntu.com/t/40792) |
+|   | ref/amc-command-reference/show | [AMC command reference - show](https://discourse.ubuntu.com/t/40793) |
+|   | ref/amc-command-reference/start | [AMC command reference - start](https://discourse.ubuntu.com/t/40794) |
+|   | ref/amc-command-reference/stop | [AMC command reference - stop](https://discourse.ubuntu.com/t/40795) |
+|   | ref/amc-command-reference/wait | [AMC command reference - wait](https://discourse.ubuntu.com/t/40796) |
 [/details]
 
 ## Redirects

--- a/ref/amc-command-reference/addon.md
+++ b/ref/amc-command-reference/addon.md
@@ -1,0 +1,47 @@
+The `addon` command allows you to manage addons that are necessary for customising images.
+
+    amc addon <subcommand>
+
+## Subcommands
+
+### `add`
+Create an addon from the contents of the provided directory, tarball or zip archive. See how to [create an addon](https://discourse.ubuntu.com/t/40632) or [create an addon tutorial](https://discourse.ubuntu.com/t/create-an-addon/25284) for more information.
+
+    amc addon add <addon_name> (<directory> | <tarball> | <zip archive>) --timeout=3m
+
+where `-t` or --`timeout` is a string value to denote the maximum wait time for the operation to complete. The default is `5m`.
+
+### `delete`
+Delete the specified addon.
+
+    amc addon delete <addon_name> [options]
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+|`-h`, `--help`| Display help information for the command. |
+|`-t`, `--timeout`| String value to denote the maximum wait time for the operation to complete. The default is `5m`. |
+|`-v`, `--version`| Indicates the version of the application for which the addon needs to be deleted. If a version is not mentioned, the addon is deleted for all versions of an application. |
+|`-y`, `--yes`| Option for non interactive deletion, assuming 'yes' as an answer to all prompt. |
+
+### `list`
+List available addons along with its application details.
+
+    amc addon list --format=(table | json |csv)
+
+where `--format` option controls the output format which can be in the form of a table, JSON or CSV. The default value is `table`.
+
+### `show`
+Display information about a specific addon, including its size and created timestamp.
+
+    amc addon show <addon_name> --format=(json | yaml)
+
+where `--format` option controls the output format which can be either JSON or YAML. The default value is `yaml`.
+
+### `update`
+Update an existing addon
+
+    amc addon update <addon_name> <addon_path> --timeout=3m
+
+where `-t` or `--timeout` is a string value to denote the maximum wait time for the operation to complete. The default is `5m`.

--- a/ref/amc-command-reference/application.md
+++ b/ref/amc-command-reference/application.md
@@ -1,0 +1,123 @@
+The `application` command allows you to manage applications using the Anbox Management Client (AMC).
+
+    amc application <subcommand>
+
+You can also use the alias `app` instead of `application`.
+
+## Subcommands
+
+### `create`
+Create an application from the contents of the directory, tarball or zip archive.
+
+    amc application create <app_name> (<directory> | <tarball> | <zip archive>) [options]
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+|`-h`, `--help`| Display help information for the command. |
+|`-t`, `--timeout`| String value to denote the maximum wait time for the operation to complete. The default is `5m`. |
+|`--vm`| Create an application using virtual machines instead of containers. |
+
+### `delete`
+Delete the specified application.
+
+    amc application delete <app_name> [options]
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+|`-a`, `--all`| Delete all existing applications. |
+|`-f`, `--force`| Force deletes of the application even if it is immutable. Applications downloaded from the registry cannot be deleted unless this flag is used. |
+|`-h`, `--help`| Displays help information for the `delete` command. |
+|`--no-wait`| Indicates not to wait for the delete operation to finish. |
+| `-t`, `--timeout`| String value that denotes the maximum wait time for the operation to complete. The default is `5m`. |
+| `-v`, `--version`| Displays the version of the application that needs to be deleted. If a version is not mentioned, the addon is deleted for all versions of an application. |
+|`-y`, `--yes`| Option for non interactive deletion, assuming 'yes' as an answer to all prompt. |
+
+### `list`
+List all available applications. You can apply filters to see a specific list of applications.
+
+    amc application list [options]
+
+You can use the alias `ls` instead of `list`.
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+|`-f`, `--filter` | Filters the output based on specified attributes. The attributes can be one of these: <br/>* `instance-type=(comma-separated list)` <br/>* `addons=(comma-separated list)` <br/>* `tags=(comma-separated list)` <br/>* `published=(true/false)` <br/>* `immutable=(true/false)` <br/>* `status=(string)` <br/>* `vm=(true/false)`|
+|`--format`| String value that controls the output format which can either be in a table form, JSON, YAML or CSV. The default value is `table`. |
+|`-h`, `--help`| Displays help information for the `list` command. |
+
+### `publish`
+Publish a version of the application. When an application is launched, AMS always uses the published version of the application unless otherwise mentioned.
+
+    amc application publish <app_name> <version> --timeout=3m
+
+where `-t` or --`timeout` is a string value to denote the maximum wait time for the operation to complete. The default is `5m`.
+
+### `revoke`
+Revoke a published application version.
+
+    amc application revoke <app_name> <version> --timeout=3m
+
+where `-t` or --`timeout` is a string value to denote the maximum wait time for the operation to complete. The default is `5m`.
+
+### `set`
+Update specific attributes of an application's manifest without creating a new version of the application.
+
+    amc application set <app_name> <field> <field_value>
+
+You can update the following fields:
+
+* `image`
+* `addons`
+* `tags`
+* `inhibit-auto-updates`
+* `resources.cpus`
+* `resources.memory`
+* `resources.disk-size`
+* `resources.gpu-slots`
+* `resources.vpu-slots`
+* `boot-activity`
+* `features`
+* `hooks.timeout`
+* `bootstrap.keep`
+* `node-selector`
+* `watchdog.disabled`
+* `watchdog.allowed-packages`
+
+### `show`
+Display information about an application and its versions.
+
+    amc application show <app_name> --format=json
+
+where `--format` controls the output formatting. The values for `--format` can be `json` or `yaml`. The output displays in YAML format by default if a format is not specified.
+
+### `unset`
+Reset an attribute of an application's manifest to its default value.
+
+    amc application unset <app_name> <field>
+
+You can reset the following attributes:
+
+* `tags`
+* `addons`
+* `features`
+
+For resetting any other attribute, use the `amc application set` command and specify the attribute value.
+
+### `update`
+Update an existing application. Updating an application creates a new version.
+
+    amc application update <app_name> <package_path> --timeout=10m
+
+where `-t` or --`timeout` is a string value to denote the maximum wait time for the operation to complete. The default is `5m`.
+
+If you don't provide a package for the update, AMS checks all possible updates by verifying the application against newer images and addons and applies pending changes as necessary.
+
+If you prefer specific updates to your application, use the `amc application set` command instead as it allows you to update specific fields of the application without updating the application.
+
+

--- a/ref/amc-command-reference/benchmark.md
+++ b/ref/amc-command-reference/benchmark.md
@@ -1,0 +1,22 @@
+The `benchmark` command allows you to benchmark your Anbox Cloud deployment. Benchmarking your deployment helps in evaluating the performance of Anbox Cloud for a well-defined workload.
+
+    amc benchmark (<app_id> | <image_id>) [options]
+
+Define the workload with the following options:
+
+|Option|Input type|Description| Default value|
+|------|-----------|-----------|-------------|
+|`-d`, `--dump-data` | | Dump data collected during the benchmark, the file name containing the data is printed | |
+| `-c`, `--force` | | Force remove instances | |
+| `-f`, `--fps`  | | Measure Frames Per Second (FPS) for all instances | |
+| `--fps-threshold` | Integer | FPS threshold below which an instance will be considered slow | 30 |
+| `-h`, `--help` | | Displays help information for `amc benchmark` command| |
+| `-s`, `--instances-per-second` | Float | Number of instances to launch per second | 0.1 |
+| `--measure-time` | String | Time spent measuring instance statistics| 1 minute |
+| `--network-address` | String | Outbound network address on which the instances can reach the benchmark executor. For example: 127.0.0.1 | |
+| `-n`, `--num-instances` | Integer | Number of instances to launch  | 1 |
+| `-p`, `--platform` | String | Anbox platform to use for the instances | `null` |
+| `-r`, `--raw` | | If specified, the instance is created for the specified image instead of an application | |
+|`--settle-time` | String | Settling time allowed for the instance performance measurement starts | 30 seconds |                 
+| `--userdata` | String | Additional user data to be sent to the created instance | |
+

--- a/ref/amc-command-reference/completion.md
+++ b/ref/amc-command-reference/completion.md
@@ -1,0 +1,80 @@
+The `completion` command allows you to generate the auto completion script for the specified shell.
+
+    amc completion <subcommand>
+
+## Subcommands
+
+### `bash`
+Generate the auto completion script for `bash`. This script depends on and requires the `bash-completion` package to be installed.
+
+    amc completion bash --no-descriptions
+
+where `--no-descriptions` disables completion descriptions.
+
+To load completions in your current shell session, use:
+
+    source <(amc completion bash)
+
+To load completions for every new session, execute the following once and start a new shell for the setup to take effect:
+
+For Linux,
+
+    amc completion bash > /etc/bash_completion.d/amc
+
+For macOS,
+
+    amc completion bash > $(brew --prefix)/etc/bash_completion.d/amc
+
+### `fish`
+Generate the auto completion script for `fish`.
+
+    amc completion fish --no-descriptions
+
+where `--no-descriptions` disables completion descriptions.
+
+To load completions in your current shell session, use:
+
+    amc completion fish | source
+
+To load completions for every new session, execute the following once and start a new shell for the set to take effect:
+
+    amc completion fish > ~/.config/fish/completions/amc.fish
+
+### `powershell`
+Generate the auto completion script for `powershell`.
+
+    amc completion powershell --no-descriptions
+
+where `--no-descriptions` disables completion descriptions.
+
+To load completions in your current shell session, use:
+
+    amc completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add the output of the above command
+to your powershell profile.
+
+### `zsh`
+Generate the auto completion script for `zsh`.
+
+    amc completion zsh --no-descriptions
+
+where `--no-descriptions` disables completion descriptions.
+
+If shell completion is not already enabled in your environment, enable it by running the following command:
+
+    echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+    source <(amc completion zsh)
+
+To load completions for every new session, execute the following once and start a new shell for the setup to take effect:
+
+For Linux,
+
+    amc completion zsh > "${fpath[1]}/_amc"
+
+For macOS,
+
+    amc completion zsh > $(brew --prefix)/share/zsh/site-functions/_amc

--- a/ref/amc-command-reference/config.md
+++ b/ref/amc-command-reference/config.md
@@ -1,0 +1,36 @@
+The `config` command helps manage the global configuration for the Anbox Management Service (AMS). See [AMS configuration](https://discourse.ubuntu.com/t/20872) for a list of
+available configuration items.
+
+    amc config <subcommand>
+
+## Subcommands
+
+### `set`
+Update a single configuration of the AMS.
+
+    amc config set <config_name> <config_value>
+
+### `show`
+Display all configuration of the AMS.
+
+    amc config show
+
+### `trust`
+Manage trusted clients that can communicate with AMS. You can add or remove client certificates as needed to allow or block communication with AMS.
+
+The `amc config trust` command can be used with three subcommands - `add`, `list` and `remove`.
+
+The `add` command adds a new trusted client that can communicate with the AMS:
+
+        amc config trust add <certificate_path>
+
+The `list` command displays a list of trusted clients:
+
+        amc config trust list --format=table
+
+where `--format` controls the output formatting. `table`, `json` and `yaml` are allowed values while `table` is the default value.
+
+The `remove` command removes a client from the list of trusted clients. You can also use `rm` as an alias.
+
+        amc config trust remove <client_name>
+

--- a/ref/amc-command-reference/delete.md
+++ b/ref/amc-command-reference/delete.md
@@ -1,0 +1,15 @@
+The `delete` command deletes an instance.
+
+    amc delete <instance_id> [options]
+
+The following options are available:
+
+| Option | Description |
+|--------|-------------|
+|`-a`, `-all`| Deletes all existing instances |
+|`-f`, `--force` | Forcibly removes an instance |
+|`-h`, `--help` | Displays help information for the command |
+|`--no-wait` | Indicates not to wait for the delete operation to finish |
+|`-n`, `--node` | This option only works when used in combination with `--all` and can be used to select only instances for the specified node. Input type: String |
+|`-t`, `--timeout` | Indicates the maximum time to wait for the operation to complete. The default value is `5m` |
+|`-y`, `--yes` | Runs non interactively assuming `yes` for all prompts |

--- a/ref/amc-command-reference/exec.md
+++ b/ref/amc-command-reference/exec.md
@@ -1,0 +1,7 @@
+The `exec` command executes commands directly inside an instance without a shell environment.
+
+    amc exec <instance_id> -- <command> [options]
+
+To use flags in your command, you must isolate the command with the '--' separator. Use `-T`, `--force-noninteractive` to disable pseudo-terminal allocation.
+
+Remember that shell patterns will not be recognised. If you need a shell environment, execute the shell command and pass the command as an argument. For example: `amc exec <instance_id> -- sh -c "cd /tmp && pwd`.

--- a/ref/amc-command-reference/help.md
+++ b/ref/amc-command-reference/help.md
@@ -1,0 +1,5 @@
+The `help` command displays detailed information about the `amc` tool.
+
+    amc help
+
+You can also use the `-h` or `--help` option on any command to read its command line help.

--- a/ref/amc-command-reference/image.md
+++ b/ref/amc-command-reference/image.md
@@ -1,0 +1,77 @@
+The `image` command manages images that contain everything necessary to properly run an Android application in an instance.
+
+Images can be provided manually or via an image server. You can add, update or
+delete them from AMS. See https://discourse.ubuntu.com/t/24185 and
+https://discourse.ubuntu.com/t/17758 for more information.
+
+    amc image <subcommand>
+
+## Subcommands
+
+### `add`
+Add an image. The first image that you add is marked as the default image. This default image is used when creating an application or launching a raw container without specifying an image. To set any image added after the first image as the default, add the '--default' flag.
+
+    amc image add <image_name> <image_path> [options]
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+| `-d`, `--default` | Marks the specified image as the default image |
+| `-h`, `--help` | Displays help information for the command |
+| `-t`, `--timeout` | String value that indicates the maximum time to wait for the operation to complete. The default value is `5m`. |
+| `--type` | String value that denotes the type of image to import. Use only when a remote image is added. Valid values for this option are `any`, `container`, `vm`. `any` is the default value. |
+
+### `delete`
+Delete an image. When an image is deleted, all of its versions are removed unless otherwise specified.
+
+    amc image delete <image_name> [options]
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+| `-f`, `--force` |  Forcibly deletes immutable images |
+| `-h`, `--help` | Displays help information for the command |
+| `-t`, `--timeout` |  String value that indicates the maximum time to wait for the operation to complete. The default value is `5m`. |
+| `-v`, `--version` | Integer that indicates the version of the image to delete |
+| `-y`, `--yes` | Runs non interactively assuming `yes` for all prompts |
+
+### `list`
+List all available images.
+
+    amc image list --format=json
+
+where `--format` controls the output formatting. Valid values are `table`, `json` or `csv` and the default value is `table`.
+
+You can use the alias `ls` instead of `list`.
+
+### `show`
+Display information about an image
+
+    amc image show <image_name> --format=json
+
+where `--format` controls the output formatting. The values for `--format` can be `json` or `yaml`. The output displays in YAML format by default if a format is not specified.
+
+### `switch`
+Set the default image. The default image is used when creating an application that does not have an image specified in the application manifest, or when launching a raw instance.
+
+    amc image switch <image_name>
+
+### `sync`
+Synchronises the image with the remote image server. If the image is used from a remote image server, this command triggers explicit sync with the remote server and the image is downloaded to the cluster from the remote server.
+
+    amc image sync <image_name>
+
+### `update`
+Update an existing image. This command replaces the specified image with the new image and bumps its version number.
+
+    amc image update <image_name> <image_path>
+
+The following options are available:
+
+|Option|Description|
+|------|-----------|
+|`-d`, `--default` | Marks the image as the default image |
+| `-h`, `--help` | Displays help information for the command |
+|`-t`, `--timeout` |  String value that indicates the maximum time to wait for the operation to complete. The default value is `5m`. |

--- a/ref/amc-command-reference/info.md
+++ b/ref/amc-command-reference/info.md
@@ -1,0 +1,5 @@
+The `info` command displays general information about the connected AMS service.
+
+    amc info --format=json
+
+where `--format` controls the output formatting. Valid values for this flag are `json` or `yaml` and `yaml` is the default value.

--- a/ref/amc-command-reference/init.md
+++ b/ref/amc-command-reference/init.md
@@ -1,0 +1,31 @@
+The `init` command creates an instance but does not start it immediately.
+
+    amc init <app_id | image_id> [options]
+
+The following options are available:
+
+| Option | Input type | Description | Default value |
+|------|--------------|-------------|---------------|
+| `-a`, `--addons` | String | Comma-separated list of addons to install in the instance. Applicable for raw instances only. | |
+| `-c`, `--cpus` | Integer | Number of CPU cores to be assigned for the instance. | 2 |
+| `--devmode` |    | Enables developer mode for the instance. | Disabled |
+| `--disable-watchdog` | | Disables watchdog for the instance. Applicable for regular instances only. | |
+| `-d`, `--disk-size` | String | Disk size of the instance. | 15 GB for a container instance;<br/> 3 GB for a virtual machine instance |
+| `--enable-graphics` | | Enables graphics for the instance | Disabled |
+| `-f`, `--features` | String | Comma-separated list of features to enable for the Anbox runtime inside the instance | |
+| `-g`, `--gpu-slots` |  Integer | Number of GPU slots to be assigned for the instance. | -1 |
+| `-h`, `--help` |  | Displays help information for the command | |
+| `-m`, `--memory` | String | Memory to be assigned for the instance | 3GB |
+| `--metrics-server` | String | Metrics server to which the instance sends its data |
+| `--no-wait` | | Indicates not to wait for the instance to start | Disabled |
+| `-n`, `--node` | String | Indicates the LXD node to use for creating the instance | |
+| `-p`, `--platform` | String | Indicates the Anbox platform to use | `null` platform |
+| `-r`, `--raw` | | Creates a raw instance for the specified image instead of an application instance | |
+|  `-s`, `--service` | String array | Services to expose on the instance's IP endpoint for external access (public or private) | |
+|  `--tags` | String | Comma-separated list of tags to set for the instance | |
+| `-t`, `--timeout` | | String value that indicates the maximum time to wait for the operation to complete. The default value is `5m`. |
+| `--userdata` | String | Additional user data to be sent to the created instance | |
+| `--userdata-path` | String | Path to a file with additional user data to be sent to the created instance |
+| `--version` | Integer | Indicates the specific version of an application or image to use when creating an instance | -1 |
+| `--vm` | | Creates a virtual machine instead of a container | Disabled |
+| `-v`, `--vpu-slots` | Integer | Indicates the number of VPU slots to be assigned for the instance. | -1 |

--- a/ref/amc-command-reference/landing.md
+++ b/ref/amc-command-reference/landing.md
@@ -4,28 +4,28 @@ Use `amc --help` or `amc <command> --help` to display usage information for the 
 
 | Command | Description|
 |---------|------------|
-|[`addon`](tbd)    | Manage addons |
-|[`application`](tbd) | Manage applications |
-|[`benchmark`](tbd) | Benchmark your Anbox Cloud deployment |
-|[`completion`](tbd) | Generate the auto completion script for the specified shell |
-|[`config`](tbd) | Manage AMS configuration |
-|[`delete`](tbd) | Delete an instance |
-|[`exec`](tbd) | Execute a command inside an instance |
-|[`help`](tbd) | Help for a command |
-|[`image`](tbd) | Manage images |
-|[`info`](tbd) | Provide information about connected AMS service |
-|[`init`](tbd) | Initialise an instance |
-|[`launch`](tbd) | Launch an instance |
-|[`list`](tbd) | List instances |
-|[`logs`](tbd) | View runtime logs of an instance |
-|[`node`](tbd) | Manage nodes |
-|[`remote`](tbd) | Interact with remote AMS daemons |
-|[`shell`](tbd) | Open a shell inside a running instance |
-|[`show`](tbd) | Display information about an instance |
-|[`show-log`](tbd) | Display a particular instance's log file |
-|[`start`](tbd) | Start an existing instance |
-|[`stop`](tbd) | Stop a running instance |
-|[`wait`](tbd) | Wait for an instance to reach a specific condition |
+|[`addon`](https://discourse.ubuntu.com/t/40775)    | Manage addons |
+|[`application`](https://discourse.ubuntu.com/t/40776) | Manage applications |
+|[`benchmark`](https://discourse.ubuntu.com/t/40777) | Benchmark your Anbox Cloud deployment |
+|[`completion`](https://discourse.ubuntu.com/t/40778) | Generate the auto completion script for the specified shell |
+|[`config`](https://discourse.ubuntu.com/t/40779) | Manage AMS configuration |
+|[`delete`](https://discourse.ubuntu.com/t/40780) | Delete an instance |
+|[`exec`](https://discourse.ubuntu.com/t/40781) | Execute a command inside an instance |
+|[`help`](https://discourse.ubuntu.com/t/40782) | Help for a command |
+|[`image`](https://discourse.ubuntu.com/t/40783) | Manage images |
+|[`info`](https://discourse.ubuntu.com/t/40784) | Provide information about connected AMS service |
+|[`init`](https://discourse.ubuntu.com/t/40785) | Initialise an instance |
+|[`launch`](https://discourse.ubuntu.com/t/40786) | Launch an instance |
+|[`list`](https://discourse.ubuntu.com/t/40787) | List instances |
+|[`logs`](https://discourse.ubuntu.com/t/40788) | View runtime logs of an instance |
+|[`node`](https://discourse.ubuntu.com/t/40789) | Manage nodes |
+|[`remote`](https://discourse.ubuntu.com/t/40790) | Interact with remote AMS daemons |
+|[`shell`](https://discourse.ubuntu.com/t/40791) | Open a shell inside a running instance |
+|[`show`](https://discourse.ubuntu.com/t/40793) | Display information about an instance |
+|[`show-log`](https://discourse.ubuntu.com/t/40792) | Display a particular instance's log file |
+|[`start`](https://discourse.ubuntu.com/t/40794) | Start an existing instance |
+|[`stop`](https://discourse.ubuntu.com/t/40795) | Stop a running instance |
+|[`wait`](https://discourse.ubuntu.com/t/40796) | Wait for an instance to reach a specific condition |
 
 ## Options
 

--- a/ref/amc-command-reference/landing.md
+++ b/ref/amc-command-reference/landing.md
@@ -1,0 +1,37 @@
+The Anbox Management Client (AMC) is a command line utility offered by Anbox Cloud that interacts with the [Anbox Management Service (AMS)](https://discourse.ubuntu.com/t/24321).
+
+Use `amc --help` or `amc <command> --help` to display usage information for the tool and its commands. The following commands are available for use with `amc`:
+
+| Command | Description|
+|---------|------------|
+|[`addon`](tbd)    | Manage addons |
+|[`application`](tbd) | Manage applications |
+|[`benchmark`](tbd) | Benchmark your Anbox Cloud deployment |
+|[`completion`](tbd) | Generate the auto completion script for the specified shell |
+|[`config`](tbd) | Manage AMS configuration |
+|[`delete`](tbd) | Delete an instance |
+|[`exec`](tbd) | Execute a command inside an instance |
+|[`help`](tbd) | Help for a command |
+|[`image`](tbd) | Manage images |
+|[`info`](tbd) | Provide information about connected AMS service |
+|[`init`](tbd) | Initialise an instance |
+|[`launch`](tbd) | Launch an instance |
+|[`list`](tbd) | List instances |
+|[`logs`](tbd) | View runtime logs of an instance |
+|[`node`](tbd) | Manage nodes |
+|[`remote`](tbd) | Interact with remote AMS daemons |
+|[`shell`](tbd) | Open a shell inside a running instance |
+|[`show`](tbd) | Display information about an instance |
+|[`show-log`](tbd) | Display a particular instance's log file |
+|[`start`](tbd) | Start an existing instance |
+|[`stop`](tbd) | Stop a running instance |
+|[`wait`](tbd) | Wait for an instance to reach a specific condition |
+
+## Options
+
+You can use the following options or flags with the `amc` utility:
+
+| Option | Description |
+|--------|-------------|
+|`-h`, `--help` | Display help for the `amc` utility |
+|`-v`, `--version` | Display version of the AMS |

--- a/ref/amc-command-reference/launch.md
+++ b/ref/amc-command-reference/launch.md
@@ -1,0 +1,31 @@
+The `launch` command launches an instance.
+
+    amc launch <app_id | image_id> [options]
+
+The following options are available:
+
+| Option | Input type | Description | Default value |
+|------|--------------|-------------|---------------|
+| `-a`, `--addons` | String | Comma-separated list of addons to install in the instance. Applicable for raw instances only. | |
+| `-c`, `--cpus` | Integer | Number of CPU cores to be assigned for the instance. | 2 |
+| `--devmode` |    | Enables developer mode for the instance. | Disabled |
+| `--disable-watchdog` | | Disables watchdog for the instance. Applicable for regular instances only. | |
+| `-d`, `--disk-size` | String | Disk size of the instance. | 15 GB for a container instance;<br/> 3 GB for a virtual machine instance |
+| `--enable-graphics` | | Enables graphics for the instance | Disabled |
+| `-f`, `--features` | String | Comma-separated list of features to enable for the Anbox runtime inside the instance | |
+| `-g`, `--gpu-slots` |  Integer | Number of GPU slots to be assigned for the instance. | -1 |
+| `-h`, `--help` |  | Displays help information for the command | |
+| `-m`, `--memory` | String | Memory to be assigned for the instance | 3GB |
+| `--metrics-server` | String | Metrics server to which the instance sends its data |
+| `--no-wait` | | Indicates not to wait for the instance to start | Disabled |
+| `-n`, `--node` | String | Indicates the LXD node to use for creating the instance | |
+| `-p`, `--platform` | String | Indicates the Anbox platform to use | `null` platform |
+| `-r`, `--raw` | | Creates a raw instance for the specified image instead of an application instance | |
+|  `-s`, `--service` | String array | Services to expose on the instance's IP endpoint for external access (public or private) | |
+|  `--tags` | String | Comma-separated list of tags to set for the instance | |
+| `-t`, `--timeout` | | String value that indicates the maximum time to wait for the operation to complete. The default value is `5m`. |
+| `--userdata` | String | Additional user data to be sent to the created instance | |
+| `--userdata-path` | String | Path to a file with additional user data to be sent to the created instance |
+| `--version` | Integer | Indicates the specific version of an application or image to use when creating an instance | -1 |
+| `--vm` | | Creates a virtual machine instead of a container | Disabled |
+| `-v`, `--vpu-slots` | Integer | Indicates the number of VPU slots to be assigned for the instance. | -1 |

--- a/ref/amc-command-reference/list.md
+++ b/ref/amc-command-reference/list.md
@@ -1,0 +1,28 @@
+The `list` command lists all the instances.
+
+    amc list [options]
+
+You can also use `ls` as an alias.
+
+The following options are available:
+
+| Options | Description |
+|---------|-------------|
+|`-f`, `--filter`| Filters the output based on specified conditions |
+| `--format` | Controls output formatting. The output format can be `table`, `json` or `csv` and the default value is `table` |
+| `-h`, `--help` | Displays help information for the command |
+
+Usage for `--filter`:
+
+        amc list --filter attribute=value
+
+where `attribute` can be one of the following:
+
+|  Name  |             Argument type              |
+|--------|----------------------------------------|
+| `app`    | string (application name)              |
+| `status` | string (prepared, started, error, etc) |
+| `node`   | string                                 |
+| `type`   | string (regular/base)                  |
+| `tags`   | comma-separated list                   |
+| `vm`     | boolean (true/false)                   |

--- a/ref/amc-command-reference/logs.md
+++ b/ref/amc-command-reference/logs.md
@@ -1,0 +1,11 @@
+The `logs` command shows runtime logs of an instance. You can display system-level logs of the instance or the nested Android container.
+
+    amc logs <instance_id> [options]
+
+The following options are available:
+
+| Option | Description |
+|--------|-------------|
+|`-f`, `--follow` | Shows only the most recent log entries and continuously prints new entries as they are appended to the log |
+| `-h`, `--help` | Displays help information for the command |
+| `-t`, `--type` | Type of logs to show: `anbox` or `android`. The default is `anbox`. |

--- a/ref/amc-command-reference/node.md
+++ b/ref/amc-command-reference/node.md
@@ -1,0 +1,92 @@
+The `node` command manage LXD nodes of the deployment that run instances with Anbox Cloud and are managed by the Anbox Management Service (AMS). See https://discourse.ubuntu.com/t/17765 for more information.
+
+    amc node <subcommand>
+
+## Subcommands
+
+### `add`
+Add a node to AMS. You can also use the alias `new`.
+
+    amc node add <node_name> <node_ip_address> [options]
+
+There are a few prerequisites for the adding a node:
+
+* The new node must have an accessible IP address.
+* LXD must be installed on the node before adding it but not initialised because AMS takes care of the initialisation and configuration of the node.
+
+The following options are available:
+
+| Option | Input type | Description |
+|--------|------------|-------------|
+|`-h`, `--help` |  | Displays help information for the command |
+| `--network`| String | Name of the network device to create on the LXD cluster. The default value is `amsbr0` |
+| `--network-bridge-mtu` | Integer | Maximum Transmission Unit of the network bridge that is configured for LXD |
+| `--network-subnet` | String | Network subnet for the network device on the node (default '192.168.100.1/20') |
+| `--storage-device` | String | Storage device that the LXD node should use |
+| `--storage-pool` | String | Existing LXD storage pool to use |
+| `--tags` | String | Comma-separated list of tags to set for the node |
+| `--trust-password` | String | Trust password for the remote LXD node |
+| `--unmanaged` | | Indicates that the node is already clustered |
+
+
+### `list`
+List available nodes. You can also use `ls` as an alias.
+
+    amc node list [options]
+
+The following options are available:
+
+| Options | Description |
+|---------|-------------|
+|`-f`, `--filter`| Filters the output based on specified conditions |
+| `--format` | Controls output formatting. The output format can be `table`, `json` or `csv` and the default value is `table` |
+| `-h`, `--help` | Displays help information for the command |
+
+Usage for `--filter`:
+
+        amc node list --filter attribute=value
+
+where `attribute` can be one of the following:
+
+|     Name      |       Argument type           |
+|---------------|-------------------------------|
+|<!-- wokeignore:rule=master --> master        | Boolean (true/false)          |
+| status        | string (online, offline etc.) |
+
+
+### `remove`
+Removes a node from the Anbox Cloud cluster thereby making it unable to host instances.
+
+[note type="information" status="Note]You cannot delete a node with running instances unless you use the `--force` flag.[/note]
+
+    amc node remove <node_name> [options]
+
+The following options are available:
+
+| Options | Description |
+|---------|-------------|
+| `-f`, `--force` | Forcibly removes the node |
+| `-h`, `--help`  | Displays help information for the command |
+| `--keep-in-cluster` | Removes the LXD node from the AMS database but keeps it as part of the cluster |
+| `-y`, `--yes` | Run non interactively by assuming 'yes' for all prompts |
+
+
+### `set`
+Set specific configuration for a node. See [AMS configuration](https://discourse.ubuntu.com/t/20872) for a list of available configuration items.
+
+    amc node set <node_name> <config_item_name> <config_item_value> [options] --timeout=10m
+
+where `-t` or --`timeout` is a string value to indicate the maximum wait time for the operation to complete. The default value is `5m`.
+
+### `show`
+Display information about a node.
+
+    amc node show <node_name> [options]
+
+The following options are available:
+
+| Option | Description |
+|--------|-------------|
+| `--allocations` | Shows resource allocations |
+|`-f`, `--format` | Controls output formatting with values `json` or `yaml`. The default value is `yaml`. |
+| `-h`, `--help` | Displays help information for the command |

--- a/ref/amc-command-reference/remote.md
+++ b/ref/amc-command-reference/remote.md
@@ -1,0 +1,34 @@
+The `remote` command allows interacting with remote Anbox Management Service (AMS) daemons. See [How to control AMS remotely](https://discourse.ubuntu.com/t/17774) for more information.
+
+    amc remote <subcommand>
+
+## Subcommands
+
+### `add`
+Add a remote AMS daemon. Note that if you set up a trust password on the daemon, provide the password when running the command.
+
+    amc remote add <remote_name> <remote_url> [trust_password] --accept-certificate
+
+where `--accept-certificate` is to implicitly accept the remote server certificate.
+
+### `list`
+List registered remotes. You can also use the alias `ls`.
+
+    amc remote list --format=json
+
+where `--format` is to control output formatting. The valid values are `table`, `json` and `csv`. The default format is `table`.
+
+### `remove`
+Remove a registered remote.
+
+    amc remote remove <remote_name>
+
+### `set-default`
+Set the default remote which is the primary remote used for requests.
+
+    amc remote set-default <remote_name>
+
+### `set-url`
+Set the URL of an existing remote.
+
+    amc remote set-url <remote_name> <remote_url>

--- a/ref/amc-command-reference/shell.md
+++ b/ref/amc-command-reference/shell.md
@@ -1,0 +1,5 @@
+The `shell` command opens a shell inside a running instance.
+
+    amc shell <instance_id>
+
+This command is an alias for `amc exec <instance_id> -- bash`.

--- a/ref/amc-command-reference/show-log.md
+++ b/ref/amc-command-reference/show-log.md
@@ -1,0 +1,5 @@
+The `show-log` command shows the log file of an instance.
+
+    amc show-log <instance_id> <log_name>
+
+Use the `amc show <instance_id>` command to get the names of the available log files that can be viewed.

--- a/ref/amc-command-reference/show.md
+++ b/ref/amc-command-reference/show.md
@@ -1,0 +1,5 @@
+The `show` command displays information about an instance.
+
+    amc show <instance_id> --format=json
+
+where `--format` option is to control the output formatting which can be `json` or `yaml`.

--- a/ref/amc-command-reference/start.md
+++ b/ref/amc-command-reference/start.md
@@ -1,0 +1,14 @@
+The `start` command starts an existing instance that is in a prepared or a stopped status. This command can be used to start an instance when:
+* An instance is just initialised with the `amc init` command and not started.
+* An instance is in an error status.
+
+        amc start <instance_id> [options]
+
+The following options are available:
+
+| Option | Description | Default value |
+|--------|-------------|---------------|
+| `-h`, `--help` | Displays help information for the command |
+| `--no-wait` | Indicates not to wait for the instance to start | Disabled |
+| `-t`, `--timeout` | Indicates the maximum time to wait for the operation to complete | 5m |
+| `-y`, `--yes` | Force start the instance from error state | |

--- a/ref/amc-command-reference/stop.md
+++ b/ref/amc-command-reference/stop.md
@@ -1,0 +1,11 @@
+The `stop` command stops a running instance.
+
+    amc stop <instance_id> [options]
+
+The following options are available:
+
+| Option | Description | Default value |
+|--------|-------------|---------------|
+| `-h`, `--help` | Displays help information for the command |
+| `--no-wait` | Indicates not to wait for the instance to start | Disabled |
+| `-t`, `--timeout` | Indicates the maximum time to wait for the operation to complete | 5m |

--- a/ref/amc-command-reference/wait.md
+++ b/ref/amc-command-reference/wait.md
@@ -1,0 +1,12 @@
+The `wait` command waits for an instance to reach a specific condition.
+
+    amc wait (<app_id> | <instance_id>) --condition <key=value> [options]
+
+The following options are available:
+
+| Option | Description | Default value |
+|--------|-------------|---------------|
+| `-c`, `--condition` | Condition in the form of a `key=value` where `key` is a supported attribute and `value` defines what to wait on. <br/>Valid attributes for applications and their versions are `published` and `status` and for instances `status`. | |
+| `-h`, `--help` | Displays help information for the command | |
+| `-s`, `--selector` | Selector to filter the application or instance. <br/>Use `--selector version=<version number>` to wait on an application version. | |
+| `-t`, `--timeout` | Indicates the maximum time to wait for the operation to complete | 5m |


### PR DESCRIPTION
This is just a stop-gap until we have the auto generated docs in place. This PR does not require a lot of review as it is mostly from the CLI, just a quick one to see if there are any outdated commands listed.