### PR TITLE
Update documentation for 1.20.1

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -276,6 +276,7 @@ UTF
 validator
 vCPU
 vCPUs
+VHAL
 viewport
 VirGL
 virglrenderer

--- a/ref/component-versions.md
+++ b/ref/component-versions.md
@@ -2,6 +2,76 @@ This documents the versions of the different components for each Anbox Cloud rel
 
 Not all components are updated with each release. When components are not updated, this is called out in the [release notes](https://discourse.ubuntu.com/t/release-notes/17842) and components are marked with `n/a` below.
 
+[Details=1.20.1]
+### Charms
+
+#### Ubuntu 22.04
+
+| Name | Channel | Revision |
+|----------|--------------|--------------|
+| `anbox-cloud-dashboard` | `1.20/stable` | 228 |
+| `ams-node-controller` | `1.20/stable` | 237 |
+| `coturn` | `1.20/stable` | 230 |
+| `ams` | `1.20/stable` | 241 |
+| `aar` | `1.20/stable` | 235 |
+| `anbox-stream-gateway` | `1.20/stable` | 246 |
+| `ams-load-balancer` | `1.20/stable` | 236 |
+| `ams-lxd` | `1.20/stable` | 233 |
+| `anbox-stream-agent` | `1.20/stable` | 241 |
+| `nats ` | `latest/stable` | 11 |
+
+#### Ubuntu 20.04
+
+| Name | Channel | Revision |
+|----------|--------------|--------------|
+| `anbox-cloud-dashboard` | `1.20/stable` | 227 |
+| `ams-node-controller` | `1.20/stable` | 236 |
+| `coturn` | `1.20/stable` | 229 |
+| `ams` | `1.20/stable` | 240 |
+| `aar` | `1.20/stable` | 234 |
+| `anbox-stream-gateway` | `1.20/stable` | 245 |
+| `ams-load-balancer` | `1.20/stable` | 235 |
+| `ams-lxd` | `1.20/stable` | 232 |
+| `anbox-stream-agent` | `1.20/stable` | 240 |
+| `nats ` | `latest/stable` | 11 |
+
+### Validated revisions of 3rd party charms
+
+n/a
+
+### Bundles
+
+| Name | Channel | Revision |
+|----------|--------------|--------------|
+| `anbox-cloud` | `1.20/stable` | 144 |
+| `anbox-cloud-core` | `1.20/stable` | 149 |
+
+### Snaps
+
+| Name |  Channel | Version |
+|----------|--------------|---------|
+| `ams`    | `1.20/stable` | 1.20.1 |
+| `aar`    | `1.20/stable` | 1.20.1 |
+| `ams-node-controller` | `1.20/stable` | 1.20.1 |
+| `anbox-cloud-dashboard` | `1.20/stable` | 1.20.1 |
+| `anbox-stream-agent` | `1.20/stable` | 1.20.1 |
+| `anbox-stream-gateway` | `1.20/stable` | 1.20.1 |
+| `anbox-cloud-appliance` | `1.20/stable` | 1.20.1 |
+
+
+### Anbox images
+
+| Name | Version |
+|----------|--------------|
+| `jammy:android13:amd64` | 1.20.1 |
+| `jammy:android13:arm64` | 1.20.1 |
+| `jammy:android12:amd64` | 1.20.1 |
+| `jammy:android12:arm64` | 1.20.1 |
+| `jammy:android11:amd64` | 1.20.1 |
+| `jammy:android11:arm64` | 1.20.1 |
+
+[/Details]
+
 [Details=1.20.0]
 ### Charms
 

--- a/ref/component-versions.md
+++ b/ref/component-versions.md
@@ -43,8 +43,8 @@ n/a
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud` | `1.20/stable` | 156 |
-| `anbox-cloud-core` | `1.20/stable` | 161 |
+| `anbox-cloud` | `1.20/stable` | 159 |
+| `anbox-cloud-core` | `1.20/stable` | 164 |
 
 ### Snaps
 

--- a/ref/component-versions.md
+++ b/ref/component-versions.md
@@ -9,30 +9,30 @@ Not all components are updated with each release. When components are not update
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud-dashboard` | `1.20/stable` | 228 |
-| `ams-node-controller` | `1.20/stable` | 237 |
-| `coturn` | `1.20/stable` | 230 |
-| `ams` | `1.20/stable` | 241 |
-| `aar` | `1.20/stable` | 235 |
-| `anbox-stream-gateway` | `1.20/stable` | 246 |
-| `ams-load-balancer` | `1.20/stable` | 236 |
-| `ams-lxd` | `1.20/stable` | 233 |
-| `anbox-stream-agent` | `1.20/stable` | 241 |
+| `anbox-cloud-dashboard` | `1.20/stable` | 259 |
+| `ams-node-controller` | `1.20/stable` | 267 |
+| `coturn` | `1.20/stable` | 261 |
+| `ams` | `1.20/stable` | 272 |
+| `aar` | `1.20/stable` | 266 |
+| `anbox-stream-gateway` | `1.20/stable` | 277 |
+| `ams-load-balancer` | `1.20/stable` | 267 |
+| `ams-lxd` | `1.20/stable` | 264 |
+| `anbox-stream-agent` | `1.20/stable` | 272 |
 | `nats ` | `latest/stable` | 11 |
 
 #### Ubuntu 20.04
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud-dashboard` | `1.20/stable` | 227 |
-| `ams-node-controller` | `1.20/stable` | 236 |
-| `coturn` | `1.20/stable` | 229 |
-| `ams` | `1.20/stable` | 240 |
-| `aar` | `1.20/stable` | 234 |
-| `anbox-stream-gateway` | `1.20/stable` | 245 |
-| `ams-load-balancer` | `1.20/stable` | 235 |
-| `ams-lxd` | `1.20/stable` | 232 |
-| `anbox-stream-agent` | `1.20/stable` | 240 |
+| `anbox-cloud-dashboard` | `1.20/stable` | 258 |
+| `ams-node-controller` | `1.20/stable` | 266 |
+| `coturn` | `1.20/stable` | 260 |
+| `ams` | `1.20/stable` | 271 |
+| `aar` | `1.20/stable` | 265 |
+| `anbox-stream-gateway` | `1.20/stable` | 276 |
+| `ams-load-balancer` | `1.20/stable` | 266 |
+| `ams-lxd` | `1.20/stable` | 263 |
+| `anbox-stream-agent` | `1.20/stable` | 271 |
 | `nats ` | `latest/stable` | 11 |
 
 ### Validated revisions of 3rd party charms
@@ -43,8 +43,8 @@ n/a
 
 | Name | Channel | Revision |
 |----------|--------------|--------------|
-| `anbox-cloud` | `1.20/stable` | 144 |
-| `anbox-cloud-core` | `1.20/stable` | 149 |
+| `anbox-cloud` | `1.20/stable` | 156 |
+| `anbox-cloud-core` | `1.20/stable` | 161 |
 
 ### Snaps
 

--- a/ref/release-notes.md
+++ b/ref/release-notes.md
@@ -7,13 +7,14 @@ The following dates for upcoming releases are not final and could vary depending
 
 | Tentative Release date | Planned release version |
 |----|----|
-|December 13 2023|Anbox Cloud 1.20.1|
-|January 17 2024|Anbox Cloud 1.20.2|
+| January 17 2024 | Anbox Cloud 1.20.2 |
+| February 14 2024 | Anbox Cloud 1.21.0 |
 
 ## Recent releases
 
 | Release date   |  Release notes  |
 |----|----|
+| December 13 2023 | [Anbox Cloud 1.20.1](tbd) |
 | November 16 2023 | [Anbox Cloud 1.20.0](https://discourse.ubuntu.com/t/40281) |
 
 ### What's new in 1.20.x?

--- a/ref/roadmap.md
+++ b/ref/roadmap.md
@@ -12,4 +12,4 @@ Anbox Cloud follows a defined release cycle with frequent minor and patch releas
 | Release | Target Date | What to expect| 
 |---------|-------------|---------------|
 | 1.20.2 | January 17 2024  | * Android security updates for January 2023<br/>* Bug fixes |
-| 1.21.0 | February 14, 2024 | * Production support for Vulkan on NVIDIA GPUs<br/>* Add VHAL support<br/>* Support for IAM role based authentication in AAR<br/>* TLS support for `anbox-cloud-nfs-operator` charm.<br/>* Android security updates for February 2023<br/>* Bug fixes |
+| 1.21.0 | February 14, 2024 | * Production support for Vulkan on NVIDIA GPUs<br/>* Add automotive-enabled Anbox Cloud images<br/>* Support for IAM role based authentication in AAR<br/>* TLS support for `anbox-cloud-nfs-operator` charm.<br/>* Android security updates for February 2023<br/>* Bug fixes |

--- a/ref/roadmap.md
+++ b/ref/roadmap.md
@@ -11,5 +11,5 @@ Anbox Cloud follows a defined release cycle with frequent minor and patch releas
 ## Roadmap
 | Release | Target Date | What to expect| 
 |---------|-------------|---------------|
-| 1.20.1 | December 13 2023 | * Android security updates for December 2023<br/>* Bug fixes |
 | 1.20.2 | January 17 2024  | * Android security updates for January 2023<br/>* Bug fixes |
+| 1.21.0 | February 14, 2024 | * Production support for Vulkan on NVIDIA GPUs<br/>* Add VHAL support<br/>* Support for IAM role based authentication in AAR<br/>* TLS support for `anbox-cloud-nfs-operator` charm.<br/>* Android security updates for February 2023<br/>* Bug fixes |


### PR DESCRIPTION
<s>The component versions need to be updated once the images are built.</s>
Update: Component versions are updated based on [this build](https://next.ci.anbox-cloud.io/view/1.20/job/deployment-scripts-stable-1.20-publish/5/console). Bundle versions may need updates once they are promoted to stable.