### PR TITLE
feat(ref): add VHAL HTTP API documentation

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -111,6 +111,7 @@ Graylog
 gRPC
 gzip
 HAProxy
+HIDL
 hotfix
 HTTPS
 HW
@@ -280,6 +281,7 @@ validator
 vCPU
 vCPUs
 VHAL
+VhalPropertyStatus
 viewport
 VirGL
 virglrenderer


### PR DESCRIPTION
This adds VHAL endpoint documentation to the HTTP API docs based on the current version of the VHAL implementation.